### PR TITLE
fix(security): harden remote-control auth and attachment proxy

### DIFF
--- a/src/infra/network/ssrf.test.ts
+++ b/src/infra/network/ssrf.test.ts
@@ -1,0 +1,90 @@
+// ssrf.test.ts — SSRF guard for outbound URL validation (V2)
+import { describe, expect, test } from "bun:test"
+import { validateEndpoint } from "./ssrf"
+
+describe("validateEndpoint (V2 SSRF guard)", () => {
+  test("accepts a valid public https URL", () => {
+    expect(validateEndpoint("https://example.com/image.png")).toEqual({ ok: true })
+  })
+
+  test("accepts a public https URL with port", () => {
+    expect(validateEndpoint("https://cdn.example.com:443/file")).toEqual({ ok: true })
+  })
+
+  test("rejects localhost", () => {
+    const result = validateEndpoint("https://localhost/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects 127.0.0.1", () => {
+    const result = validateEndpoint("https://127.0.0.1/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects 0.0.0.0", () => {
+    const result = validateEndpoint("https://0.0.0.0/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects ::1 (IPv6 loopback)", () => {
+    const result = validateEndpoint("https://[::1]/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects RFC 1918 10.x.x.x", () => {
+    const result = validateEndpoint("https://10.0.0.1/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects RFC 1918 192.168.x.x", () => {
+    const result = validateEndpoint("https://192.168.1.1/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects RFC 1918 172.16.x.x", () => {
+    const result = validateEndpoint("https://172.16.0.1/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects RFC 1918 172.31.x.x", () => {
+    const result = validateEndpoint("https://172.31.255.255/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("allows 172.15.x.x (just outside RFC 1918 range)", () => {
+    const result = validateEndpoint("https://172.15.0.1/image.png")
+    expect(result.ok).toBe(true)
+  })
+
+  test("rejects link-local 169.254.x.x", () => {
+    const result = validateEndpoint("https://169.254.1.1/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects IPv6 unique-local fc00::", () => {
+    const result = validateEndpoint("https://[fc00::1]/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects IPv6 unique-local fd00::", () => {
+    const result = validateEndpoint("https://[fd00::1]/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects IPv6 link-local fe80::", () => {
+    const result = validateEndpoint("https://[fe80::1]/secret")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects non-https URL (http://)", () => {
+    // Guard for attachment proxy: block non-public hosts; http: is rejected by push service
+    // For attachments the guard must also handle http:// input
+    const result = validateEndpoint("http://localhost/file")
+    expect(result.ok).toBe(false)
+  })
+
+  test("rejects invalid URL (not parseable)", () => {
+    const result = validateEndpoint("not-a-url")
+    expect(result.ok).toBe(false)
+  })
+})

--- a/src/infra/network/ssrf.ts
+++ b/src/infra/network/ssrf.ts
@@ -1,0 +1,61 @@
+// ─── SSRF guard ───────────────────────────────────────────────────────────────
+// Validates outbound URLs against server-side request forgery vectors.
+// Lives in infra/network/ so both notifications/ and transport/ can import
+// without violating the sibling cross-import rule.
+//
+// Originally defined in notifications/channels/push/service.ts; relocated here
+// so transport/http/handlers/sessions.ts can apply the same guard to the
+// attachment proxy without creating a cross-sibling dependency.
+
+/**
+ * Validate an outbound URL against SSRF vectors.
+ *
+ * Blocks loopback, RFC 1918 private ranges, link-local, and IPv6 private
+ * addresses. Requires HTTPS (push subscriptions) — callers that accept http://
+ * MUST enforce their own scheme policy.
+ *
+ * Known residual limitations (string/hostname-based guard, by design):
+ *  - No DNS resolution: a public hostname that resolves to a private address
+ *    (DNS rebinding) is not detected here.
+ *  - No IP-format normalization: alternate encodings (decimal/octal/hex) of an
+ *    address are not canonicalized before matching.
+ * These are accepted given the trusted-source contexts this guard runs in
+ * (SDK-supplied attachment URLs, user push endpoints). Defense-in-depth, not a
+ * complete egress firewall.
+ *
+ * Return contract: `{ ok: true }` | `{ ok: false; reason: string }`.
+ */
+export function validateEndpoint(raw: string): { ok: true } | { ok: false; reason: string } {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    return { ok: false, reason: 'invalid URL' }
+  }
+  if (url.protocol !== 'https:') {
+    return { ok: false, reason: 'endpoint must use https:' }
+  }
+  const host = url.hostname.toLowerCase()
+  // Strip IPv6 brackets added by URL parser (e.g. [::1] → ::1)
+  const bare = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
+  // Loopback / unspecified
+  if (
+    bare === 'localhost' ||
+    bare === '0.0.0.0' ||
+    bare === '127.0.0.1' ||
+    bare === '::1'
+  ) {
+    return { ok: false, reason: 'localhost endpoints are not allowed' }
+  }
+  // RFC 1918 private ranges (IPv4)
+  if (/^10\./.test(bare)) return { ok: false, reason: 'private IP range not allowed' }
+  if (/^192\.168\./.test(bare)) return { ok: false, reason: 'private IP range not allowed' }
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(bare)) return { ok: false, reason: 'private IP range not allowed' }
+  // Link-local (IPv4)
+  if (/^169\.254\./.test(bare)) return { ok: false, reason: 'link-local address not allowed' }
+  // Unique-local / link-local (IPv6)
+  if (bare.startsWith('fc') || bare.startsWith('fd') || bare.startsWith('fe80:')) {
+    return { ok: false, reason: 'private IPv6 range not allowed' }
+  }
+  return { ok: true }
+}

--- a/src/notifications/channels/push/service.ts
+++ b/src/notifications/channels/push/service.ts
@@ -21,11 +21,14 @@ import { createSubscriptionStore } from './subscriptions'
 import { loadWebPush, generateVapidKeys as generateVapidKeysUtil } from './vapid'
 import type { VapidGenerateResult } from './vapid'
 import type { PushSubscriptionJson, PushPayload } from './types'
+import { validateEndpoint } from '../../../infra/network/ssrf'
 
 // Re-export types so callers that previously imported from service.ts still work
 export type { PushSubscriptionJson, PushPayload }
 export type { PushSubscriptionKeys } from './types'
 export type { VapidGenerateResult } from './vapid'
+// Re-export so existing callers of service.validateEndpoint continue to work
+export { validateEndpoint } from '../../../infra/network/ssrf'
 
 export interface PushService {
   /** The NotificationChannel slice — passed to the notification pipeline. */
@@ -57,47 +60,6 @@ function isValidSubscription(v: unknown): v is PushSubscriptionJson {
   if (!keys || typeof keys !== 'object') return false
   const k = keys as Record<string, unknown>
   return typeof k.p256dh === 'string' && typeof k.auth === 'string'
-}
-
-/**
- * Validate a Web Push endpoint URL against SSRF vectors.
- *
- * Push endpoints MUST use HTTPS and MUST NOT resolve to localhost, link-local,
- * or RFC 1918 private ranges. An attacker registering a subscription with an
- * endpoint pointing at an internal service would turn the server into an SSRF
- * proxy — each broadcast call would make an outgoing POST to that URL.
- */
-export function validateEndpoint(raw: string): { ok: true } | { ok: false; reason: string } {
-  let url: URL
-  try {
-    url = new URL(raw)
-  } catch {
-    return { ok: false, reason: 'invalid URL' }
-  }
-  if (url.protocol !== 'https:') {
-    return { ok: false, reason: 'endpoint must use https:' }
-  }
-  const host = url.hostname.toLowerCase()
-  // Loopback / unspecified
-  if (
-    host === 'localhost' ||
-    host === '0.0.0.0' ||
-    host === '127.0.0.1' ||
-    host === '::1'
-  ) {
-    return { ok: false, reason: 'localhost endpoints are not allowed' }
-  }
-  // RFC 1918 private ranges (IPv4)
-  if (/^10\./.test(host)) return { ok: false, reason: 'private IP range not allowed' }
-  if (/^192\.168\./.test(host)) return { ok: false, reason: 'private IP range not allowed' }
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return { ok: false, reason: 'private IP range not allowed' }
-  // Link-local (IPv4)
-  if (/^169\.254\./.test(host)) return { ok: false, reason: 'link-local address not allowed' }
-  // Unique-local / link-local (IPv6)
-  if (host.startsWith('fc') || host.startsWith('fd') || host.startsWith('fe80:')) {
-    return { ok: false, reason: 'private IPv6 range not allowed' }
-  }
-  return { ok: true }
 }
 
 export interface PushDeps {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -260,13 +260,17 @@ export default {
         projectStateMode: config.projectStateMode,
       })
 
+      const tokenPreview =
+        currentToken.length > 10
+          ? `${currentToken.slice(0, 4)}...${currentToken.slice(-4)}`
+          : currentToken.slice(0, 4) + "..."
       await ctx.client.app
         .log({
           body: {
             service: "opencode-pilot",
             level: "info",
             message: `Remote control active on ${config.host}:${config.port}`,
-            extra: { token: currentToken },
+            extra: { tokenPreview },
           },
         })
         .catch(() => {})

--- a/src/transport/http/handlers/events.test.ts
+++ b/src/transport/http/handlers/events.test.ts
@@ -1,0 +1,151 @@
+// events.test.ts — streamEvents auth tests (V1: timing-safe query token)
+import { describe, expect, test } from "bun:test"
+import type { RouteDeps, RouteContext } from "../routes"
+import { streamEvents } from "./events"
+import type { Logger } from "../../../infra/logger/index"
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+}
+
+function makeEventsDeps(token = "valid-token"): RouteDeps {
+  return {
+    client: {} as RouteDeps["client"],
+    project: {} as RouteDeps["project"],
+    directory: "/tmp",
+    worktree: "/tmp",
+    config: {
+      port: 4097,
+      host: "127.0.0.1",
+      permissionTimeoutMs: 300_000,
+      tunnel: "off",
+      telegram: null,
+      dev: false,
+      vapid: null,
+      enableGlobOpener: false,
+      fetchTimeoutMs: 10_000,
+      projectStateMode: "auto",
+      codexPermissionTimeoutMs: 300_000,
+    },
+    token,
+    rotateToken: () => {},
+    tunnelUrl: null,
+    audit: { log: () => {} } as RouteDeps["audit"],
+    eventBus: {
+      createSSEResponse: (_headers?: Record<string, string>) =>
+        new Response("data: ping\n\n", {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      emit: () => {},
+      hasClients: () => false,
+      clientCount: () => 0,
+      closeAll: () => {},
+    } as RouteDeps["eventBus"],
+    permissionQueue: {} as RouteDeps["permissionQueue"],
+    codexPermissionQueue: {} as RouteDeps["codexPermissionQueue"],
+    telegram: {} as RouteDeps["telegram"],
+    push: {} as RouteDeps["push"],
+    logger: silentLogger,
+    settingsStore: {
+      load: () => ({}),
+      save: (_p: unknown) => ({}),
+      reset: () => {},
+      filePath: () => "/tmp/c.json",
+    } as unknown as RouteDeps["settingsStore"],
+    shellEnv: {},
+    envFileApplied: [],
+    pilotVersion: "0.0.0-test",
+    settingsLoader: {
+      loadEffective: () => ({
+        effective: {} as RouteDeps["config"],
+        settings: {
+          port: 4097,
+          host: "127.0.0.1",
+          permissionTimeoutMs: 300_000,
+          tunnel: "off" as const,
+          telegramToken: "",
+          telegramChatId: "",
+          vapidPublicKey: "",
+          vapidPrivateKey: "",
+          vapidSubject: "",
+          enableGlobOpener: false,
+          fetchTimeoutMs: 10_000,
+          projectStateMode: "auto" as const,
+          hookTokenConfigured: false,
+        },
+        sources: {},
+      }),
+      envKeyFor: () => "",
+      restartRequiredFields: [],
+    },
+  }
+}
+
+function makeEventsCtx(
+  deps: RouteDeps,
+  opts?: { bearerToken?: string | null; queryToken?: string | null },
+): RouteContext {
+  const params = new URLSearchParams()
+  if (opts?.queryToken !== undefined && opts.queryToken !== null) {
+    params.set("token", opts.queryToken)
+  }
+
+  const url = new URL(`http://test/events?${params.toString()}`)
+  const headers: Record<string, string> = {}
+  if (opts?.bearerToken !== null && opts?.bearerToken !== undefined) {
+    headers["Authorization"] = `Bearer ${opts.bearerToken}`
+  }
+
+  const req = new Request(url.toString(), { headers })
+  return { req, url, params: {}, deps }
+}
+
+// ─── V1: query token uses timing-safe comparison ─────────────────────────────
+
+describe("streamEvents — ?token= query auth (V1 timing-safe)", () => {
+  test("correct query token → 200 SSE response", async () => {
+    const deps = makeEventsDeps("my-secret-token")
+    const ctx = makeEventsCtx(deps, { queryToken: "my-secret-token" })
+    const res = await streamEvents(ctx)
+    expect(res.status).toBe(200)
+  })
+
+  test("wrong query token → 401", async () => {
+    const deps = makeEventsDeps("my-secret-token")
+    const ctx = makeEventsCtx(deps, { queryToken: "wrong-token" })
+    const res = await streamEvents(ctx)
+    expect(res.status).toBe(401)
+  })
+
+  test("null query token with no bearer → 401", async () => {
+    const deps = makeEventsDeps("my-secret-token")
+    const ctx = makeEventsCtx(deps, { bearerToken: null, queryToken: null })
+    const res = await streamEvents(ctx)
+    expect(res.status).toBe(401)
+  })
+
+  test("empty query token → 401 (reject non-public hosts)", async () => {
+    const deps = makeEventsDeps("my-secret-token")
+    const ctx = makeEventsCtx(deps, { bearerToken: null, queryToken: "" })
+    const res = await streamEvents(ctx)
+    expect(res.status).toBe(401)
+  })
+
+  test("correct Bearer header → 200 (bearer path still works)", async () => {
+    const deps = makeEventsDeps("my-secret-token")
+    const ctx = makeEventsCtx(deps, { bearerToken: "my-secret-token" })
+    const res = await streamEvents(ctx)
+    expect(res.status).toBe(200)
+  })
+
+  test("wrong Bearer header → 401", async () => {
+    const deps = makeEventsDeps("my-secret-token")
+    const ctx = makeEventsCtx(deps, { bearerToken: "wrong" })
+    const res = await streamEvents(ctx)
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/transport/http/handlers/events.ts
+++ b/src/transport/http/handlers/events.ts
@@ -1,7 +1,7 @@
 import type { RouteContext } from "../routes"
 import { jsonError } from "../middlewares/json"
 import { CORS_HEADERS } from "../middlewares/cors"
-import { validateToken } from "../middlewares/auth"
+import { validateToken, safeEqual } from "../middlewares/auth"
 import { MSG } from "../../../core/strings"
 
 function getIP(req: Request): string {
@@ -13,7 +13,8 @@ function getIP(req: Request): string {
 export async function streamEvents({ req, url, deps }: RouteContext): Promise<Response> {
   const queryToken = url.searchParams.get("token")
   const headerValid = validateToken(req, deps.token)
-  const queryValid = queryToken === deps.token
+  // Timing-safe compare for ?token= path — mirrors the Bearer path in validateToken
+  const queryValid = queryToken !== null && safeEqual(queryToken, deps.token)
 
   if (!headerValid && !queryValid) {
     deps.audit.log("auth.failed", { path: "/events", ip: getIP(req) })

--- a/src/transport/http/handlers/sessions.test.ts
+++ b/src/transport/http/handlers/sessions.test.ts
@@ -399,3 +399,52 @@ describe("getSessionAttachment — happy path", () => {
     }
   })
 })
+
+// ─── V2: SSRF guard in HTTP attachment proxy ──────────────────────────────────
+
+describe("getSessionAttachment — SSRF guard (V2)", () => {
+  test("403 when https attachment URL targets localhost", async () => {
+    const localPart = { ...FILE_PART, url: "https://localhost/secret.png" }
+    const deps = makeAttachmentDeps({
+      client: makeMockClient({ partOverride: localPart }),
+    })
+    const ctx = makeAttachmentCtx(deps)
+    const res = await getSessionAttachment(ctx)
+    expect(res.status).toBe(403)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("FORBIDDEN")
+  })
+
+  test("403 when https attachment URL targets RFC 1918 address", async () => {
+    const privatePart = { ...FILE_PART, url: "https://192.168.1.1/secret.png" }
+    const deps = makeAttachmentDeps({
+      client: makeMockClient({ partOverride: privatePart }),
+    })
+    const ctx = makeAttachmentCtx(deps)
+    const res = await getSessionAttachment(ctx)
+    expect(res.status).toBe(403)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("FORBIDDEN")
+  })
+
+  test("403 when http attachment URL targets localhost (reject non-public host)", async () => {
+    const localHttpPart = { ...FILE_PART, url: "http://localhost/secret.png" }
+    const deps = makeAttachmentDeps({
+      client: makeMockClient({ partOverride: localHttpPart }),
+    })
+    const ctx = makeAttachmentCtx(deps)
+    const res = await getSessionAttachment(ctx)
+    // http:// to localhost: SSRF guard returns { ok: false } → 403
+    expect(res.status).toBe(403)
+  })
+
+  test("403 when http attachment URL targets 127.0.0.1", async () => {
+    const localHttpPart = { ...FILE_PART, url: "http://127.0.0.1/secret.png" }
+    const deps = makeAttachmentDeps({
+      client: makeMockClient({ partOverride: localHttpPart }),
+    })
+    const ctx = makeAttachmentCtx(deps)
+    const res = await getSessionAttachment(ctx)
+    expect(res.status).toBe(403)
+  })
+})

--- a/src/transport/http/handlers/sessions.ts
+++ b/src/transport/http/handlers/sessions.ts
@@ -7,7 +7,8 @@ import {
   validatePromptBody,
 } from "../validators/sessions"
 import { extractDirectory } from "./system"
-import { validateToken } from "../middlewares/auth"
+import { validateToken, safeEqual } from "../middlewares/auth"
+import { validateEndpoint } from "../../../infra/network/ssrf"
 import { ATTACHMENT_MAX_BYTES, MIME_SAFELIST } from "../../../server/constants"
 import type { FilePart } from "@opencode-ai/sdk"
 
@@ -304,6 +305,13 @@ async function fetchHttp(
   url: string,
   deps: RouteContext["deps"],
 ): Promise<Bytes | StructuredError> {
+  // SSRF guard: blocks non-HTTPS schemes and non-public hosts on SDK-supplied
+  // attachment URLs. The attachment proxy intentionally inherits the HTTPS-only
+  // policy from validateEndpoint (http:// attachment URLs are rejected here).
+  const endpointCheck = validateEndpoint(url)
+  if (!endpointCheck.ok) {
+    return { ok: false, error: "FORBIDDEN", detail: "attachment url blocked by ssrf guard", httpStatus: 403 }
+  }
   const timeoutMs = deps.config.fetchTimeoutMs ?? 10_000
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
@@ -399,7 +407,8 @@ export async function getSessionAttachment({
   // Auth: Bearer header OR ?token= query param (mirrors /events pattern)
   const queryToken = url.searchParams.get("token")
   const headerValid = validateToken(req, deps.token)
-  const queryValid = queryToken !== null && queryToken === deps.token
+  // Timing-safe compare for ?token= path — mirrors the Bearer path in validateToken
+  const queryValid = queryToken !== null && safeEqual(queryToken, deps.token)
   if (!headerValid && !queryValid) {
     deps.audit.log("auth.failed", { path: "/sessions/:id/attachments/:partId" })
     return jsonError("UNAUTHORIZED", "Missing or invalid authorization token", 401, CORS_HEADERS)

--- a/src/transport/http/handlers/settings.test.ts
+++ b/src/transport/http/handlers/settings.test.ts
@@ -498,3 +498,52 @@ describe("POST /settings/reset handler", () => {
     expect(raw).not.toContain("hookToken")
   })
 })
+
+// ─── V3: hookToken live-update on PATCH /settings ────────────────────────────
+
+describe("V3 hookToken live-update (mutable container)", () => {
+  let dir: string
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pilot-v3-hooktoken-"))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test("PATCH /settings with hookToken updates deps.config.hookToken in-memory", async () => {
+    const configPath = join(dir, "config.json")
+    const deps = makeDeps({ configPath })
+    // Boot state: no hookToken
+    expect(deps.config.hookToken).toBeUndefined()
+
+    const req = new Request("http://test/settings", {
+      method: "PATCH",
+      body: JSON.stringify({ hookToken: "live-token-abc" }),
+    })
+    const res = await patchSettings(makeCtx(deps, req))
+    expect(res.status).toBe(200)
+
+    // deps.config.hookToken must be live-updated without restart
+    expect(deps.config.hookToken).toBe("live-token-abc")
+  })
+
+  test("PATCH /settings with hookToken:null clears deps.config.hookToken in-memory", async () => {
+    const configPath = join(dir, "config.json")
+    // Start with a hookToken set in the store
+    writeFileSync(configPath, JSON.stringify({ hookToken: "old-token" }), "utf-8")
+    const config = loadConfig({})
+    config.hookToken = "old-token"
+    const deps = makeDeps({ configPath, config })
+    expect(deps.config.hookToken).toBe("old-token")
+
+    const req = new Request("http://test/settings", {
+      method: "PATCH",
+      body: JSON.stringify({ hookToken: null }),
+    })
+    const res = await patchSettings(makeCtx(deps, req))
+    expect(res.status).toBe(200)
+
+    // After clearing, hookToken must be undefined in memory
+    expect(deps.config.hookToken).toBeUndefined()
+  })
+})

--- a/src/transport/http/handlers/settings.ts
+++ b/src/transport/http/handlers/settings.ts
@@ -226,6 +226,20 @@ export async function patchSettings({ req, deps }: RouteContext): Promise<Respon
     keys: Object.keys(validation.data),
   })
 
+  // Live-update hookToken on the shared deps.config so subsequent requests
+  // (e.g. Codex hook auth) see the new value without restart.
+  // Mirrors the rotateToken mutable-container pattern used for the main token.
+  // Shell-env-pinned fields are already rejected above — this path only runs
+  // for store-sourced values.
+  if ('hookToken' in validation.data) {
+    const newHookToken = validation.data.hookToken
+    // null means "clear" (see validateSettingsPatch: null → empty string sentinel)
+    // The store sanitize() drops empty strings, so an empty string here = cleared.
+    deps.config.hookToken = (newHookToken && newHookToken.length > 0)
+      ? newHookToken
+      : undefined
+  }
+
   return json(sanitizeSettingsResponse(buildSettingsResponse(deps)), 200, CORS_HEADERS)
 }
 


### PR DESCRIPTION
## Summary

Security hardening pass on the network-exposed remote-control surface. Tracked privately under advisory **`GHSA-3px3-jr37-xcw7`** (draft); full impact/details remain private until a patched version is released, per `SECURITY.md`.

This PR contains the fixes only — no exploit details, repro steps, or PoC.

## Changes

- **Timing-safe auth on `?token=` paths.** `GET /events` and the attachment proxy now use the same constant-time comparison primitive as the `Authorization: Bearer` path (previously a plain string compare).
- **SSRF guard on the attachment proxy.** Outbound fetches are validated before the request. The guard was relocated to `src/infra/network/ssrf.ts` so `transport/` and `notifications/` share a single implementation **without** a cross-sibling import (respects the dependency rule). This also fixes a latent IPv6 bracket-notation matching bug in the original guard. Known residual limits (no DNS resolution / no alternate-IP-encoding normalization) are documented in the guard's JSDoc — it is defense-in-depth for trusted-source URLs, not a full egress firewall.
- **Live Codex hook-token resolution.** `PATCH /settings` changes to the hook token (set and clear) now take effect without a process restart; shell-env precedence preserved; comparison stays timing-safe.
- **Boot-log redaction.** The raw auth token is no longer emitted in the structured app log at startup — preview only.

## Architecture / scope

- No cross-sibling imports introduced; `infra/ ← core/ ← (transport/, integrations/, notifications/)` rule respected.
- No new `any`, no non-Error classes, no `console.log` in the server path.
- Net production change is small (~46 lines); the bulk of the diff is added tests. The unrelated parked doc in the working tree was deliberately excluded from this commit.

## Testing

- [x] `bun test` — 558 pass / 0 fail (+29 new tests covering each fixed path)
- [x] `tsc --noEmit` — clean
- [x] Independent fresh-context review completed (verdict: approve; actionable nits addressed)

Refs: `GHSA-3px3-jr37-xcw7` (private). Does **not** close #25 (non-security code-health items are tracked separately there).
