### PR TITLE
test(integrations,notifications): cover native hooks + pipeline

### DIFF
--- a/src/integrations/opencode/hooks/event.test.ts
+++ b/src/integrations/opencode/hooks/event.test.ts
@@ -1,0 +1,283 @@
+// Tests for createEventHook — sessionBusyStart Map lifecycle
+// Covers: busy→idle under threshold, busy→idle over threshold, session.error,
+// and whether sessionBusyStart is cleaned up on session.error.
+import { describe, expect, test } from "bun:test"
+import { createEventHook } from "./event"
+import type { NotificationService } from "../../../core/types/notification-service"
+import type { PluginInput } from "@opencode-ai/plugin"
+
+// ─── Minimal fake NotificationService ────────────────────────────────────────
+
+type NotifyCall = {
+  kind: "idle" | "error"
+  sessionID: string
+  error?: string
+}
+
+function makeNotifications(opts?: {
+  notifyPermissionPendingResult?: boolean
+}): NotificationService & { calls: NotifyCall[]; emitted: Array<{ type: string }> } {
+  const calls: NotifyCall[] = []
+  const emitted: Array<{ type: string }> = []
+  return {
+    calls,
+    emitted,
+    emit(event) {
+      emitted.push({ type: event.type })
+    },
+    emitPilot(event) {
+      emitted.push({ type: event.type })
+    },
+    async notifyPermissionPending() {
+      return opts?.notifyPermissionPendingResult ?? false
+    },
+    async notifySessionIdle(_client, sessionID) {
+      calls.push({ kind: "idle", sessionID })
+    },
+    async notifySessionError(_client, sessionID, error) {
+      calls.push({ kind: "error", sessionID, error })
+    },
+    async flush() {},
+  }
+}
+
+// ─── Minimal fake client ──────────────────────────────────────────────────────
+
+function makeClient(): PluginInput["client"] {
+  return {} as PluginInput["client"]
+}
+
+// ─── Minimal fake audit ───────────────────────────────────────────────────────
+
+type AuditEntry = { action: string; details: Record<string, unknown> }
+
+function makeAudit(entries: AuditEntry[] = []) {
+  return {
+    entries,
+    log(action: string, details: Record<string, unknown>) {
+      entries.push({ action, details })
+    },
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeStatusEvent(sessionID: string, statusType: "busy" | "idle") {
+  return {
+    event: {
+      type: "session.status",
+      properties: {
+        sessionID,
+        status: { type: statusType },
+      },
+    },
+  }
+}
+
+function makeErrorEvent(sessionID: string, errorMessage = "something went wrong") {
+  return {
+    event: {
+      type: "session.error",
+      properties: {
+        sessionID,
+        error: {
+          data: { message: errorMessage },
+        },
+      },
+    },
+  }
+}
+
+// ─── busy→idle UNDER threshold (≤10s) — no notification ─────────────────────
+
+describe("session.status busy→idle under 10s threshold", () => {
+  test("no idle notification when busy duration ≤ threshold", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), makeAudit())
+
+    // Manually inject a busy start time just 1 second ago (under 10s)
+    const sessionID = "sess-under"
+    sessionBusyStart.set(sessionID, Date.now() - 1_000)
+
+    await hook(makeStatusEvent(sessionID, "idle"))
+
+    expect(notifications.calls.filter(c => c.kind === "idle")).toHaveLength(0)
+  })
+
+  test("sessionBusyStart entry is deleted when under threshold", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), makeAudit())
+
+    const sessionID = "sess-under-delete"
+    sessionBusyStart.set(sessionID, Date.now() - 1_000)
+
+    await hook(makeStatusEvent(sessionID, "idle"))
+
+    // The entry must be cleaned up regardless of threshold outcome
+    // ACTUAL behavior: the entry is NOT deleted when under threshold (the code
+    // only deletes inside the `if (started && Date.now() - started > 10_000)` block)
+    // This is a characterization test for the real behavior:
+    expect(sessionBusyStart.has(sessionID)).toBe(true) // NOT cleaned up when under threshold
+  })
+})
+
+// ─── busy→idle OVER threshold (>10s) — should notify ─────────────────────────
+
+describe("session.status busy→idle over 10s threshold", () => {
+  test("idle notification IS sent when busy duration > 10s", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), makeAudit())
+
+    const sessionID = "sess-over"
+    // Inject a busy start 11 seconds ago (over 10s threshold)
+    sessionBusyStart.set(sessionID, Date.now() - 11_000)
+
+    await hook(makeStatusEvent(sessionID, "idle"))
+
+    const idleCalls = notifications.calls.filter(c => c.kind === "idle" && c.sessionID === sessionID)
+    expect(idleCalls).toHaveLength(1)
+  })
+
+  test("sessionBusyStart entry IS deleted when over threshold", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), makeAudit())
+
+    const sessionID = "sess-over-delete"
+    sessionBusyStart.set(sessionID, Date.now() - 11_000)
+
+    await hook(makeStatusEvent(sessionID, "idle"))
+
+    expect(sessionBusyStart.has(sessionID)).toBe(false) // cleaned up when over threshold
+  })
+})
+
+// ─── busy event sets sessionBusyStart ─────────────────────────────────────────
+
+describe("session.status busy sets sessionBusyStart", () => {
+  test("busy event records a start time for the session", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), makeAudit())
+
+    const sessionID = "sess-busy"
+    const before = Date.now()
+    await hook(makeStatusEvent(sessionID, "busy"))
+    const after = Date.now()
+
+    expect(sessionBusyStart.has(sessionID)).toBe(true)
+    const recorded = sessionBusyStart.get(sessionID)!
+    expect(recorded).toBeGreaterThanOrEqual(before)
+    expect(recorded).toBeLessThanOrEqual(after)
+  })
+})
+
+// ─── session.error — notify is called ─────────────────────────────────────────
+
+describe("session.error behavior", () => {
+  test("session.error fires notifySessionError with the correct sessionID and error message", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), makeAudit())
+
+    const sessionID = "sess-err"
+    const errorMessage = "the model timed out"
+
+    await hook(makeErrorEvent(sessionID, errorMessage))
+
+    const errorCalls = notifications.calls.filter(c => c.kind === "error")
+    expect(errorCalls).toHaveLength(1)
+    expect(errorCalls[0]!.sessionID).toBe(sessionID)
+    expect(errorCalls[0]!.error).toBe(errorMessage)
+  })
+
+  test("session.error falls back to String(props.error) when errorObj.data.message is absent", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), makeAudit())
+
+    const sessionID = "sess-err-fallback"
+    await hook({
+      event: {
+        type: "session.error",
+        properties: {
+          sessionID,
+          error: "flat string error",
+        },
+      },
+    })
+
+    const errorCalls = notifications.calls.filter(c => c.kind === "error")
+    expect(errorCalls).toHaveLength(1)
+    expect(errorCalls[0]!.error).toBe("flat string error")
+  })
+
+  // ─── LATENT BUG CHARACTERIZATION TEST ─────────────────────────────────────
+  // The audit flagged that sessionBusyStart is NOT cleaned up on session.error.
+  // This test asserts the ACTUAL current behavior (NOT fixed here — see final summary).
+  test("CHARACTERIZATION: sessionBusyStart is NOT cleaned up on session.error", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), makeAudit())
+
+    const sessionID = "sess-err-cleanup"
+
+    // First mark the session busy
+    await hook(makeStatusEvent(sessionID, "busy"))
+    expect(sessionBusyStart.has(sessionID)).toBe(true) // sanity check
+
+    // Now fire session.error — the code at event.ts:39-45 does NOT touch sessionBusyStart
+    await hook(makeErrorEvent(sessionID, "crashed"))
+
+    // ACTUAL behavior: entry remains in the map (possible memory leak)
+    expect(sessionBusyStart.has(sessionID)).toBe(true)
+  })
+})
+
+// ─── All events are forwarded to the SSE bus ──────────────────────────────────
+
+describe("all events forwarded to notifications.emit", () => {
+  test("every event type is forwarded regardless of session.status logic", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), makeAudit())
+
+    await hook({ event: { type: "tool.completed", properties: { sessionID: "s1", result: "ok" } } })
+    await hook({ event: { type: "session.status", properties: { sessionID: "s1", status: { type: "busy" } } } })
+
+    expect(notifications.emitted.length).toBeGreaterThanOrEqual(2)
+    expect(notifications.emitted.some(e => e.type === "tool.completed")).toBe(true)
+    expect(notifications.emitted.some(e => e.type === "session.status")).toBe(true)
+  })
+
+  test("audit.log is called for every event", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const auditEntries: AuditEntry[] = []
+    const audit = makeAudit(auditEntries)
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), audit)
+
+    await hook({ event: { type: "tool.completed", properties: {} } })
+    await hook({ event: { type: "session.error", properties: { sessionID: "x", error: "e" } } })
+
+    expect(auditEntries.filter(e => e.action === "event")).toHaveLength(2)
+  })
+})
+
+// ─── idle event without prior busy entry ─────────────────────────────────────
+
+describe("idle event with no prior busy entry", () => {
+  test("idle with no busyStart entry does NOT notify", async () => {
+    const sessionBusyStart = new Map<string, number>()
+    const notifications = makeNotifications()
+    const hook = createEventHook(notifications, sessionBusyStart, makeClient(), makeAudit())
+
+    // Never set busy — sessionBusyStart is empty
+    await hook(makeStatusEvent("sess-no-busy", "idle"))
+
+    expect(notifications.calls.filter(c => c.kind === "idle")).toHaveLength(0)
+  })
+})

--- a/src/integrations/opencode/hooks/permission.ask.test.ts
+++ b/src/integrations/opencode/hooks/permission.ask.test.ts
@@ -1,0 +1,253 @@
+// Tests for createPermissionAskHook — SECURITY-CRITICAL
+// Covers: no-remote-channel path (falls through to TUI), remote-reachable path
+// (blocks and waits), allow/deny resolution, timeout fallback to TUI.
+import { describe, expect, test } from "bun:test"
+import { createPermissionAskHook } from "./permission.ask"
+import type { PermissionOutput } from "./permission.ask"
+import { createPermissionQueue } from "../../../core/permissions/queue"
+import type { NotificationService } from "../../../core/types/notification-service"
+import type { Permission } from "@opencode-ai/sdk"
+
+// ─── Fake NotificationService ─────────────────────────────────────────────────
+
+function makeNotifications(notifyReturn: boolean): NotificationService & { calls: unknown[] } {
+  const calls: unknown[] = []
+  return {
+    calls,
+    emit() {},
+    emitPilot() {},
+    async notifyPermissionPending(...args) {
+      calls.push({ method: "notifyPermissionPending", args })
+      return notifyReturn
+    },
+    async notifySessionIdle() {},
+    async notifySessionError() {},
+    async flush() {},
+  }
+}
+
+// ─── Fake audit ───────────────────────────────────────────────────────────────
+
+type AuditEntry = { action: string; details: Record<string, unknown> }
+
+function makeAudit(entries: AuditEntry[] = []) {
+  return {
+    entries,
+    log(action: string, details: Record<string, unknown>) {
+      entries.push({ action, details })
+    },
+  }
+}
+
+// ─── Minimal Permission fixture ───────────────────────────────────────────────
+
+function makePermission(overrides: Partial<Permission> = {}): Permission {
+  return {
+    id: "perm-001",
+    title: "Allow bash: rm -rf /",
+    sessionID: "sess-1",
+    type: "execute",
+    pattern: "bash",
+    metadata: {},
+    ...overrides,
+  } as Permission
+}
+
+// ─── No remote channel — fall through to TUI ──────────────────────────────────
+
+describe("permission.ask — no remote channel (notifyPermissionPending returns false)", () => {
+  test("output.status is NOT set — TUI handles permission", async () => {
+    const notifications = makeNotifications(false)
+    const queue = createPermissionQueue(5_000)
+    const audit = makeAudit()
+    const hook = createPermissionAskHook(notifications, queue, audit)
+
+    const input = makePermission()
+    const output: PermissionOutput = {}
+
+    await hook(input, output)
+
+    // No remote channel → output.status stays undefined (TUI asks)
+    expect(output.status).toBeUndefined()
+  })
+
+  test("permission.noRemoteChannel is audited when no channel is reachable", async () => {
+    const notifications = makeNotifications(false)
+    const queue = createPermissionQueue(5_000)
+    const auditEntries: AuditEntry[] = []
+    const audit = makeAudit(auditEntries)
+    const hook = createPermissionAskHook(notifications, queue, audit)
+
+    const input = makePermission()
+    await hook(input, {})
+
+    const entry = auditEntries.find(e => e.action === "permission.noRemoteChannel")
+    expect(entry).toBeDefined()
+    expect(entry?.details.permissionID).toBe("perm-001")
+  })
+
+  test("queue.waitForResponse is NOT called when no channel is reachable", async () => {
+    const notifications = makeNotifications(false)
+    let waitCalled = false
+    const queue = {
+      waitForResponse: async () => { waitCalled = true; return null },
+      resolve: () => false,
+      pending: () => [],
+    }
+    const hook = createPermissionAskHook(notifications, queue, makeAudit())
+
+    await hook(makePermission(), {})
+
+    expect(waitCalled).toBe(false)
+  })
+})
+
+// ─── Remote channel reachable — allow ─────────────────────────────────────────
+
+describe("permission.ask — remote channel reachable, result: allow", () => {
+  test("output.status is set to 'allow' when remote resolves allow", async () => {
+    const notifications = makeNotifications(true)
+    const queue = createPermissionQueue(5_000)
+    const hook = createPermissionAskHook(notifications, queue, makeAudit())
+
+    const input = makePermission({ id: "perm-allow" })
+    const output: PermissionOutput = {}
+
+    // Resolve in background once the waiter is registered
+    const resolver = (async () => {
+      const deadline = Date.now() + 2_000
+      while (Date.now() < deadline) {
+        const pending = queue.pending()
+        if (pending.length > 0) {
+          queue.resolve("perm-allow", "allow")
+          return
+        }
+        await new Promise<void>(r => setTimeout(r, 0))
+      }
+      throw new Error("resolver: queue never populated")
+    })()
+
+    await hook(input, output)
+    await resolver
+
+    expect(output.status).toBe("allow")
+  })
+
+  test("permission.resolved is audited with action:allow and source:remote", async () => {
+    const notifications = makeNotifications(true)
+    const queue = createPermissionQueue(5_000)
+    const auditEntries: AuditEntry[] = []
+    const hook = createPermissionAskHook(notifications, queue, makeAudit(auditEntries))
+
+    const input = makePermission({ id: "perm-allow-audit" })
+    const output: PermissionOutput = {}
+
+    const resolver = (async () => {
+      const deadline = Date.now() + 2_000
+      while (Date.now() < deadline) {
+        if (queue.pending().length > 0) { queue.resolve("perm-allow-audit", "allow"); return }
+        await new Promise<void>(r => setTimeout(r, 0))
+      }
+      throw new Error("resolver: timed out")
+    })()
+
+    await hook(input, output)
+    await resolver
+
+    const entry = auditEntries.find(e => e.action === "permission.resolved")
+    expect(entry).toBeDefined()
+    expect(entry?.details.action).toBe("allow")
+    expect(entry?.details.source).toBe("remote")
+    expect(entry?.details.permissionID).toBe("perm-allow-audit")
+  })
+})
+
+// ─── Remote channel reachable — deny ──────────────────────────────────────────
+
+describe("permission.ask — remote channel reachable, result: deny", () => {
+  test("output.status is set to 'deny' when remote resolves deny", async () => {
+    const notifications = makeNotifications(true)
+    const queue = createPermissionQueue(5_000)
+    const hook = createPermissionAskHook(notifications, queue, makeAudit())
+
+    const input = makePermission({ id: "perm-deny" })
+    const output: PermissionOutput = {}
+
+    const resolver = (async () => {
+      const deadline = Date.now() + 2_000
+      while (Date.now() < deadline) {
+        if (queue.pending().length > 0) { queue.resolve("perm-deny", "deny"); return }
+        await new Promise<void>(r => setTimeout(r, 0))
+      }
+      throw new Error("resolver: timed out")
+    })()
+
+    await hook(input, output)
+    await resolver
+
+    expect(output.status).toBe("deny")
+  })
+})
+
+// ─── Remote channel reachable — timeout → falls back to TUI ──────────────────
+
+describe("permission.ask — remote channel reachable but times out", () => {
+  test("output.status stays undefined (TUI fallback) on queue timeout", async () => {
+    const notifications = makeNotifications(true)
+    // Very short timeout so test runs fast
+    const queue = createPermissionQueue(100)
+    const hook = createPermissionAskHook(notifications, queue, makeAudit())
+
+    const input = makePermission({ id: "perm-timeout" })
+    const output: PermissionOutput = {}
+
+    // Don't resolve — let it time out
+    await hook(input, output)
+
+    // waitForResponse returns null on timeout; output.status should NOT be set
+    expect(output.status).toBeUndefined()
+  }, 2_000)
+
+  test("no audit entry for permission.resolved when timeout occurs", async () => {
+    const notifications = makeNotifications(true)
+    const queue = createPermissionQueue(100)
+    const auditEntries: AuditEntry[] = []
+    const hook = createPermissionAskHook(notifications, queue, makeAudit(auditEntries))
+
+    const input = makePermission({ id: "perm-timeout-audit" })
+    await hook(input, {})
+
+    const resolved = auditEntries.find(e => e.action === "permission.resolved")
+    expect(resolved).toBeUndefined()
+  }, 2_000)
+})
+
+// ─── notifyPermissionPending receives correct arguments ───────────────────────
+
+describe("permission.ask — notifyPermissionPending receives correct arguments", () => {
+  test("passes permissionID, title, sessionID, type, pattern, metadata to notify", async () => {
+    const notifications = makeNotifications(false) // false = no wait needed
+    const queue = createPermissionQueue(5_000)
+    const hook = createPermissionAskHook(notifications, queue, makeAudit())
+
+    const input = makePermission({
+      id: "perm-args",
+      title: "Allow edit",
+      sessionID: "sess-args",
+      type: "edit",
+      pattern: "**/*.ts",
+      metadata: { risk: "medium" },
+    })
+    await hook(input, {})
+
+    expect(notifications.calls).toHaveLength(1)
+    const call = notifications.calls[0] as { method: string; args: unknown[] }
+    expect(call.method).toBe("notifyPermissionPending")
+    expect(call.args[0]).toBe("perm-args")
+    expect(call.args[1]).toBe("Allow edit")
+    expect(call.args[2]).toBe("sess-args")
+    expect(call.args[3]).toBe("edit")
+    expect(call.args[4]).toBe("**/*.ts")
+    expect(call.args[5]).toEqual({ risk: "medium" })
+  })
+})

--- a/src/integrations/opencode/hooks/tool.test.ts
+++ b/src/integrations/opencode/hooks/tool.test.ts
@@ -1,0 +1,238 @@
+// Tests for createToolHooks — tool.started / tool.completed event emission
+// Covers: pilot.tool.started, pilot.tool.completed, pilot.subagent.spawned for
+// Task-like tools, non-Task tools, and the known TODO about child sessionID.
+import { describe, expect, test } from "bun:test"
+import { createToolHooks } from "./tool"
+import type { NotificationService } from "../../../core/types/notification-service"
+import type { PilotEvent } from "../../../core/events/types"
+
+// ─── Fake NotificationService ─────────────────────────────────────────────────
+
+function makeNotifications(): NotificationService & { pilotEvents: PilotEvent[] } {
+  const pilotEvents: PilotEvent[] = []
+  return {
+    pilotEvents,
+    emit() {},
+    emitPilot(event) {
+      pilotEvents.push(event)
+    },
+    async notifyPermissionPending() { return false },
+    async notifySessionIdle() {},
+    async notifySessionError() {},
+    async flush() {},
+  }
+}
+
+// ─── pilot.tool.started ───────────────────────────────────────────────────────
+
+describe("handleToolBefore — pilot.tool.started", () => {
+  test("emits pilot.tool.started with tool, sessionID, callID", async () => {
+    const notifications = makeNotifications()
+    const { handleToolBefore } = createToolHooks(notifications)
+
+    await handleToolBefore({ tool: "bash", sessionID: "sess-1", callID: "call-1" })
+
+    const started = notifications.pilotEvents.find(e => e.type === "pilot.tool.started")
+    expect(started).toBeDefined()
+    expect(started?.properties).toMatchObject({
+      tool: "bash",
+      sessionID: "sess-1",
+      callID: "call-1",
+    })
+  })
+
+  test("emits pilot.tool.started even when output is undefined", async () => {
+    const notifications = makeNotifications()
+    const { handleToolBefore } = createToolHooks(notifications)
+
+    await handleToolBefore({ tool: "edit", sessionID: "sess-2", callID: "call-2" }, undefined)
+
+    const started = notifications.pilotEvents.find(e => e.type === "pilot.tool.started")
+    expect(started).toBeDefined()
+  })
+})
+
+// ─── pilot.tool.completed ─────────────────────────────────────────────────────
+
+describe("handleToolAfter — pilot.tool.completed", () => {
+  test("emits pilot.tool.completed with tool, sessionID, callID, title, ok:true", async () => {
+    const notifications = makeNotifications()
+    const { handleToolAfter } = createToolHooks(notifications)
+
+    await handleToolAfter(
+      { tool: "bash", sessionID: "sess-1", callID: "call-1" },
+      { title: "Ran bash command" },
+    )
+
+    const completed = notifications.pilotEvents.find(e => e.type === "pilot.tool.completed")
+    expect(completed).toBeDefined()
+    expect(completed?.properties).toMatchObject({
+      tool: "bash",
+      sessionID: "sess-1",
+      callID: "call-1",
+      title: "Ran bash command",
+      ok: true,
+    })
+  })
+
+  test("ok is always true (tools reaching after-hook ran to completion)", async () => {
+    const notifications = makeNotifications()
+    const { handleToolAfter } = createToolHooks(notifications)
+
+    await handleToolAfter(
+      { tool: "read_file", sessionID: "s", callID: "c" },
+      { title: "Read file" },
+    )
+
+    const completed = notifications.pilotEvents.find(e => e.type === "pilot.tool.completed")
+    expect((completed?.properties as Record<string, unknown>).ok).toBe(true)
+  })
+})
+
+// ─── isTaskTool — pilot.subagent.spawned ─────────────────────────────────────
+
+describe("handleToolBefore — pilot.subagent.spawned for Task-like tools", () => {
+  const taskVariants = ["task", "Task", "TASK", "task.execute", "task:run", "task.spawn"]
+
+  for (const toolName of taskVariants) {
+    test(`emits pilot.subagent.spawned for tool="${toolName}"`, async () => {
+      const notifications = makeNotifications()
+      const { handleToolBefore } = createToolHooks(notifications)
+
+      await handleToolBefore(
+        { tool: toolName, sessionID: "sess-task", callID: "call-task" },
+        { args: { description: "Do something useful" } },
+      )
+
+      const spawned = notifications.pilotEvents.find(e => e.type === "pilot.subagent.spawned")
+      expect(spawned).toBeDefined()
+      expect(spawned?.properties).toMatchObject({
+        sessionID: "sess-task",
+        callID: "call-task",
+        tool: toolName,
+      })
+    })
+  }
+
+  test("pilot.subagent.spawned includes description from args.description", async () => {
+    const notifications = makeNotifications()
+    const { handleToolBefore } = createToolHooks(notifications)
+
+    await handleToolBefore(
+      { tool: "task", sessionID: "s", callID: "c" },
+      { args: { description: "Run integration tests" } },
+    )
+
+    const spawned = notifications.pilotEvents.find(e => e.type === "pilot.subagent.spawned")
+    expect((spawned?.properties as Record<string, unknown>).description).toBe("Run integration tests")
+  })
+
+  test("pilot.subagent.spawned falls back to args.prompt (truncated to 120) when description absent", async () => {
+    const notifications = makeNotifications()
+    const { handleToolBefore } = createToolHooks(notifications)
+
+    const longPrompt = "x".repeat(200)
+    await handleToolBefore(
+      { tool: "task", sessionID: "s", callID: "c" },
+      { args: { prompt: longPrompt } },
+    )
+
+    const spawned = notifications.pilotEvents.find(e => e.type === "pilot.subagent.spawned")
+    const description = (spawned?.properties as Record<string, unknown>).description
+    expect(typeof description).toBe("string")
+    expect((description as string).length).toBeLessThanOrEqual(120)
+  })
+
+  test("pilot.subagent.spawned description is undefined when neither description nor prompt", async () => {
+    const notifications = makeNotifications()
+    const { handleToolBefore } = createToolHooks(notifications)
+
+    await handleToolBefore(
+      { tool: "task", sessionID: "s", callID: "c" },
+      { args: {} },
+    )
+
+    const spawned = notifications.pilotEvents.find(e => e.type === "pilot.subagent.spawned")
+    expect((spawned?.properties as Record<string, unknown>).description).toBeUndefined()
+  })
+})
+
+// ─── Non-Task tools do NOT emit pilot.subagent.spawned ───────────────────────
+
+describe("handleToolBefore — non-Task tools do NOT spawn", () => {
+  const nonTaskTools = ["bash", "edit", "read", "write", "glob", "grep", "computer"]
+
+  for (const toolName of nonTaskTools) {
+    test(`no pilot.subagent.spawned for tool="${toolName}"`, async () => {
+      const notifications = makeNotifications()
+      const { handleToolBefore } = createToolHooks(notifications)
+
+      await handleToolBefore(
+        { tool: toolName, sessionID: "s", callID: "c" },
+        { args: {} },
+      )
+
+      const spawned = notifications.pilotEvents.find(e => e.type === "pilot.subagent.spawned")
+      expect(spawned).toBeUndefined()
+    })
+  }
+})
+
+// ─── TODO characterization: child sessionID is not exposed ────────────────────
+
+describe("CHARACTERIZATION: child sessionID not exposed in subagent.spawned", () => {
+  test("pilot.subagent.spawned properties do NOT include a childSessionID field", async () => {
+    const notifications = makeNotifications()
+    const { handleToolBefore } = createToolHooks(notifications)
+
+    await handleToolBefore(
+      { tool: "task", sessionID: "parent-sess", callID: "call-x" },
+      { args: { description: "child work" } },
+    )
+
+    const spawned = notifications.pilotEvents.find(e => e.type === "pilot.subagent.spawned")
+    expect(spawned).toBeDefined()
+    // The TODO in tool.ts notes the child sessionID is not exposed by the plugin hook.
+    // Assert current (intentionally limited) behavior:
+    expect("childSessionID" in (spawned?.properties ?? {})).toBe(false)
+    // Only the parent sessionID is present
+    expect((spawned?.properties as Record<string, unknown>).sessionID).toBe("parent-sess")
+  })
+})
+
+// ─── Both events emitted together for Task tool ───────────────────────────────
+
+describe("handleToolBefore — Task tool emits both tool.started and subagent.spawned", () => {
+  test("emits pilot.tool.started AND pilot.subagent.spawned for task tool", async () => {
+    const notifications = makeNotifications()
+    const { handleToolBefore } = createToolHooks(notifications)
+
+    await handleToolBefore(
+      { tool: "task", sessionID: "s", callID: "c" },
+      { args: { description: "parallel work" } },
+    )
+
+    const types = notifications.pilotEvents.map(e => e.type)
+    expect(types).toContain("pilot.tool.started")
+    expect(types).toContain("pilot.subagent.spawned")
+  })
+})
+
+// ─── args source: output.args only (not input fields) ────────────────────────
+
+describe("handleToolBefore — description only comes from output.args, not input fields", () => {
+  test("when output is undefined, description is undefined even for task tool", async () => {
+    const notifications = makeNotifications()
+    const { handleToolBefore } = createToolHooks(notifications)
+
+    // Pass no output (undefined) — the hook reads output?.args ?? {}, so args = {}
+    await handleToolBefore(
+      { tool: "task", sessionID: "s", callID: "c" },
+    )
+
+    const spawned = notifications.pilotEvents.find(e => e.type === "pilot.subagent.spawned")
+    // Since output is undefined, args = output?.args ?? {} = {}, so description = undefined.
+    // This characterizes that description comes ONLY from output.args, not from input itself.
+    expect((spawned?.properties as Record<string, unknown>).description).toBeUndefined()
+  })
+})

--- a/src/notifications/pipeline.test.ts
+++ b/src/notifications/pipeline.test.ts
@@ -1,0 +1,481 @@
+// Tests for createNotificationService (pipeline fan-out)
+// Covers: notifyPermissionPending return value, SSE-reachability gating,
+// fire-and-forget channel dispatch, flush no-op, emit/emitPilot wiring.
+import { describe, expect, test } from "bun:test"
+import { createNotificationService } from "./pipeline"
+import type { NotificationServiceDeps } from "./pipeline"
+import type { EventBus } from "../core/events/bus"
+import type { TelegramChannel } from "./channels/telegram/index"
+import type { PushService } from "./channels/push/service"
+import type { AuditLog } from "../core/audit/log"
+import type { NotificationChannel, NotificationEvent, NotificationResult } from "./ports"
+import type { BusEvent } from "../core/events/types"
+
+// ─── Fake EventBus ────────────────────────────────────────────────────────────
+
+function makeEventBus(opts?: { hasClients?: boolean }): EventBus & { emitted: BusEvent[] } {
+  const emitted: BusEvent[] = []
+  return {
+    emitted,
+    emit(event) { emitted.push(event) },
+    createSSEResponse: () => new Response(""),
+    hasClients: () => opts?.hasClients ?? false,
+    clientCount: () => (opts?.hasClients ? 1 : 0),
+    closeAll: () => {},
+  }
+}
+
+// ─── Fake TelegramChannel ─────────────────────────────────────────────────────
+
+type TelegramCall = { method: string; args: unknown[] }
+
+function makeTelegram(opts?: { enabled?: boolean }): TelegramChannel & { calls: TelegramCall[] } {
+  const calls: TelegramCall[] = []
+  const isEnabled = opts?.enabled ?? false
+  return {
+    name: "telegram" as const,
+    calls,
+    enabled: () => isEnabled,
+    send: async (_event) => { calls.push({ method: "send", args: [_event] }); return { ok: true } },
+    sendMessage: async (text) => { calls.push({ method: "sendMessage", args: [text] }) },
+    sendPermissionRequest: async (id, title, sessionId) => {
+      calls.push({ method: "sendPermissionRequest", args: [id, title, sessionId] })
+    },
+    sendStartup: async (url) => { calls.push({ method: "sendStartup", args: [url] }) },
+    sendSessionIdle: async (sessionId, title) => {
+      calls.push({ method: "sendSessionIdle", args: [sessionId, title] })
+    },
+    sendSessionError: async (sessionId, title, error) => {
+      calls.push({ method: "sendSessionError", args: [sessionId, title, error] })
+    },
+    testConnection: async () => ({ ok: true }),
+    stop: () => {},
+  }
+}
+
+// ─── Fake PushService ─────────────────────────────────────────────────────────
+
+function makePush(opts?: {
+  enabled?: boolean
+  subscriptionCount?: number
+}): PushService & { broadcasts: unknown[] } {
+  const broadcasts: unknown[] = []
+  const channel: NotificationChannel = {
+    name: "push",
+    enabled: () => opts?.enabled ?? false,
+    send: async () => ({ ok: true }),
+  }
+  return {
+    broadcasts,
+    channel,
+    isEnabled: () => opts?.enabled ?? false,
+    addSubscription: () => ({ ok: true }),
+    removeSubscription: () => {},
+    broadcast: async (payload) => { broadcasts.push(payload) },
+    sendTo: async () => true,
+    count: () => opts?.subscriptionCount ?? 0,
+    generateVapid: async () => ({ ok: true as const, publicKey: "", privateKey: "" }),
+  }
+}
+
+// ─── Fake AuditLog ────────────────────────────────────────────────────────────
+
+type AuditEntry = { action: string; details: Record<string, unknown> }
+
+function makeAudit(entries: AuditEntry[] = []): AuditLog & { entries: AuditEntry[] } {
+  return {
+    entries,
+    log(action, details) { entries.push({ action, details }) },
+  }
+}
+
+// ─── Fake extra channel ───────────────────────────────────────────────────────
+
+function makeChannel(opts?: {
+  enabled?: boolean
+  name?: string
+}): NotificationChannel & { sentEvents: NotificationEvent[]; shouldFail?: boolean } {
+  const sentEvents: NotificationEvent[] = []
+  return {
+    sentEvents,
+    name: opts?.name ?? "extra",
+    enabled: () => opts?.enabled ?? true,
+    send: async (event) => {
+      sentEvents.push(event)
+      return { ok: true }
+    },
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeDeps(overrides?: Partial<NotificationServiceDeps>): NotificationServiceDeps & {
+  eventBus: ReturnType<typeof makeEventBus>
+  telegram: ReturnType<typeof makeTelegram>
+  push: ReturnType<typeof makePush>
+  audit: ReturnType<typeof makeAudit>
+} {
+  const eventBus = (overrides?.eventBus as ReturnType<typeof makeEventBus>) ?? makeEventBus()
+  const telegram = (overrides?.telegram as ReturnType<typeof makeTelegram>) ?? makeTelegram()
+  const push = (overrides?.push as ReturnType<typeof makePush>) ?? makePush()
+  const audit = (overrides?.audit as ReturnType<typeof makeAudit>) ?? makeAudit()
+  return {
+    eventBus,
+    telegram,
+    push,
+    audit,
+    channels: overrides?.channels,
+  }
+}
+
+// ─── notifyPermissionPending: return value (security-critical) ────────────────
+
+describe("notifyPermissionPending — return value controls whether permission hook blocks", () => {
+  test("returns false when SSE has no clients, telegram disabled, push disabled", async () => {
+    const deps = makeDeps({
+      eventBus: makeEventBus({ hasClients: false }),
+      telegram: makeTelegram({ enabled: false }),
+      push: makePush({ enabled: false }),
+    })
+    const svc = createNotificationService(deps)
+
+    const result = await svc.notifyPermissionPending("p1", "title", "sess", "execute")
+    expect(result).toBe(false)
+  })
+
+  test("returns true when SSE has clients", async () => {
+    const deps = makeDeps({
+      eventBus: makeEventBus({ hasClients: true }),
+      telegram: makeTelegram({ enabled: false }),
+      push: makePush({ enabled: false }),
+    })
+    const svc = createNotificationService(deps)
+
+    const result = await svc.notifyPermissionPending("p2", "title", "sess", "execute")
+    expect(result).toBe(true)
+  })
+
+  test("returns true when telegram is enabled (regardless of SSE/push)", async () => {
+    const deps = makeDeps({
+      eventBus: makeEventBus({ hasClients: false }),
+      telegram: makeTelegram({ enabled: true }),
+      push: makePush({ enabled: false }),
+    })
+    const svc = createNotificationService(deps)
+
+    const result = await svc.notifyPermissionPending("p3", "title", "sess", "execute")
+    expect(result).toBe(true)
+  })
+
+  test("returns true when push is enabled with at least one subscription", async () => {
+    const deps = makeDeps({
+      eventBus: makeEventBus({ hasClients: false }),
+      telegram: makeTelegram({ enabled: false }),
+      push: makePush({ enabled: true, subscriptionCount: 1 }),
+    })
+    const svc = createNotificationService(deps)
+
+    const result = await svc.notifyPermissionPending("p4", "title", "sess", "execute")
+    expect(result).toBe(true)
+  })
+
+  test("returns false when push enabled but 0 subscriptions", async () => {
+    const deps = makeDeps({
+      eventBus: makeEventBus({ hasClients: false }),
+      telegram: makeTelegram({ enabled: false }),
+      push: makePush({ enabled: true, subscriptionCount: 0 }),
+    })
+    const svc = createNotificationService(deps)
+
+    const result = await svc.notifyPermissionPending("p5", "title", "sess", "execute")
+    expect(result).toBe(false)
+  })
+})
+
+// ─── notifyPermissionPending: SSE event emitted only when hasClients ──────────
+
+describe("notifyPermissionPending — SSE pilot.permission.pending emitted only when reachable", () => {
+  test("pilot.permission.pending IS emitted when SSE has clients", async () => {
+    const deps = makeDeps({ eventBus: makeEventBus({ hasClients: true }) })
+    const svc = createNotificationService(deps)
+
+    await svc.notifyPermissionPending("perm-sse", "Allow bash", "sess-1", "execute")
+
+    const pending = deps.eventBus.emitted.find(e => e.type === "pilot.permission.pending")
+    expect(pending).toBeDefined()
+    const props = pending?.properties as Record<string, unknown>
+    expect(props.permissionID).toBe("perm-sse")
+    expect(props.title).toBe("Allow bash")
+    expect(props.sessionID).toBe("sess-1")
+  })
+
+  test("pilot.permission.pending is NOT emitted when no SSE clients", async () => {
+    const deps = makeDeps({
+      eventBus: makeEventBus({ hasClients: false }),
+      telegram: makeTelegram({ enabled: false }),
+      push: makePush({ enabled: false }),
+    })
+    const svc = createNotificationService(deps)
+
+    await svc.notifyPermissionPending("perm-no-sse", "title", "sess", "execute")
+
+    const pending = deps.eventBus.emitted.find(e => e.type === "pilot.permission.pending")
+    expect(pending).toBeUndefined()
+  })
+
+  test("audit.log permission.requested is called when SSE has clients", async () => {
+    const auditEntries: AuditEntry[] = []
+    const audit = makeAudit(auditEntries)
+    const deps = makeDeps({ eventBus: makeEventBus({ hasClients: true }), audit })
+    const svc = createNotificationService(deps)
+
+    await svc.notifyPermissionPending("perm-audit", "title", "sess", "execute")
+
+    const entry = auditEntries.find(e => e.action === "permission.requested")
+    expect(entry).toBeDefined()
+  })
+})
+
+// ─── notifyPermissionPending: fire-and-forget channel dispatch ────────────────
+
+describe("notifyPermissionPending — fire-and-forget channel dispatch", () => {
+  test("enabled extra channel receives permission.pending event", async () => {
+    const channel = makeChannel({ enabled: true })
+    const deps = makeDeps({ channels: [channel] })
+    const svc = createNotificationService(deps)
+
+    await svc.notifyPermissionPending("perm-ch", "Allow read", "sess", "read")
+
+    // Channel dispatch is fire-and-forget — flush to let micro-tasks settle
+    await new Promise<void>(r => setTimeout(r, 10))
+
+    expect(channel.sentEvents.some(e => e.kind === "permission.pending")).toBe(true)
+  })
+
+  test("disabled extra channel is skipped", async () => {
+    const channel = makeChannel({ enabled: false })
+    const deps = makeDeps({ channels: [channel] })
+    const svc = createNotificationService(deps)
+
+    await svc.notifyPermissionPending("perm-ch-off", "title", "sess", "execute")
+
+    await new Promise<void>(r => setTimeout(r, 10))
+
+    expect(channel.sentEvents).toHaveLength(0)
+  })
+
+  test("one failing channel does not prevent other channels from receiving the event", async () => {
+    const failingChannel: NotificationChannel & { calls: number } = {
+      calls: 0,
+      name: "failing",
+      enabled: () => true,
+      send: async () => {
+        failingChannel.calls++
+        throw new Error("channel exploded")
+      },
+    }
+    const goodChannel = makeChannel({ enabled: true, name: "good" })
+    const auditEntries: AuditEntry[] = []
+    const audit = makeAudit(auditEntries)
+
+    const deps = makeDeps({ channels: [failingChannel, goodChannel], audit })
+    const svc = createNotificationService(deps)
+
+    // Should not throw — await directly and assert it resolves cleanly
+    const result = await svc.notifyPermissionPending("perm-fail", "title", "sess", "execute")
+    expect(typeof result).toBe("boolean")
+
+    await new Promise<void>(r => setTimeout(r, 20))
+
+    // Good channel still received the event
+    expect(goodChannel.sentEvents.some(e => e.kind === "permission.pending")).toBe(true)
+    // Failure was audited
+    expect(auditEntries.some(e => e.action === "channel.send_failed")).toBe(true)
+  })
+})
+
+// ─── emit / emitPilot ─────────────────────────────────────────────────────────
+
+describe("emit and emitPilot", () => {
+  test("emit forwards raw BusEvent to eventBus.emit", () => {
+    const deps = makeDeps()
+    const svc = createNotificationService(deps)
+
+    svc.emit({ type: "session.status", properties: { sessionID: "s1", status: { type: "busy" } } })
+
+    expect(deps.eventBus.emitted.some(e => e.type === "session.status")).toBe(true)
+  })
+
+  test("emitPilot forwards PilotEvent to eventBus.emit", () => {
+    const deps = makeDeps()
+    const svc = createNotificationService(deps)
+
+    svc.emitPilot({ type: "pilot.tool.started", properties: { tool: "bash", sessionID: "s", callID: "c" } })
+
+    expect(deps.eventBus.emitted.some(e => e.type === "pilot.tool.started")).toBe(true)
+  })
+
+  test("emitPilot records event.pilot in audit log", () => {
+    const auditEntries: AuditEntry[] = []
+    const deps = makeDeps({ audit: makeAudit(auditEntries) })
+    const svc = createNotificationService(deps)
+
+    svc.emitPilot({ type: "pilot.tool.started", properties: { tool: "bash", sessionID: "s", callID: "c" } })
+
+    const entry = auditEntries.find(e => e.action === "event.pilot")
+    expect(entry).toBeDefined()
+    expect(entry?.details.type).toBe("pilot.tool.started")
+  })
+})
+
+// ─── flush ────────────────────────────────────────────────────────────────────
+
+describe("flush", () => {
+  test("flush resolves without error (currently a no-op)", async () => {
+    const deps = makeDeps()
+    const svc = createNotificationService(deps)
+
+    await expect(svc.flush()).resolves.toBeUndefined()
+  })
+})
+
+// ─── notifySessionIdle — fan-out to extra channels ───────────────────────────
+
+describe("notifySessionIdle — fan-out to extra channels", () => {
+  test("enabled channel receives session.idle event", async () => {
+    const channel = makeChannel({ enabled: true })
+    const deps = makeDeps({ channels: [channel] })
+    const svc = createNotificationService(deps)
+
+    // Fake client that returns a session
+    const fakeClient = {
+      session: {
+        get: async () => ({ data: { title: "My Session" } }),
+      },
+    } as unknown as Parameters<typeof svc.notifySessionIdle>[0]
+
+    await svc.notifySessionIdle(fakeClient, "sess-idle")
+
+    expect(channel.sentEvents.some(e => e.kind === "session.idle")).toBe(true)
+  })
+
+  test("disabled channel is not called during session.idle", async () => {
+    const channel = makeChannel({ enabled: false })
+    const deps = makeDeps({ channels: [channel] })
+    const svc = createNotificationService(deps)
+
+    const fakeClient = {
+      session: {
+        get: async () => ({ data: { title: "My Session" } }),
+      },
+    } as unknown as Parameters<typeof svc.notifySessionIdle>[0]
+
+    await svc.notifySessionIdle(fakeClient, "sess-idle-off")
+
+    expect(channel.sentEvents).toHaveLength(0)
+  })
+})
+
+// ─── notifySessionError — fan-out to extra channels ──────────────────────────
+
+describe("notifySessionError — fan-out to extra channels", () => {
+  test("enabled channel receives session.error event", async () => {
+    const channel = makeChannel({ enabled: true })
+    const deps = makeDeps({ channels: [channel] })
+    const svc = createNotificationService(deps)
+
+    const fakeClient = {
+      session: {
+        get: async () => ({ data: { title: "My Session" } }),
+      },
+    } as unknown as Parameters<typeof svc.notifySessionError>[0]
+
+    await svc.notifySessionError(fakeClient, "sess-err", "crashed")
+
+    expect(channel.sentEvents.some(e => e.kind === "session.error")).toBe(true)
+    const errEvent = channel.sentEvents.find(e => e.kind === "session.error")
+    expect(errEvent?.payload.error).toBe("crashed")
+  })
+
+  test("telegram.send_failed is audited when session lookup throws in notifySessionIdle", async () => {
+    const auditEntries: AuditEntry[] = []
+    const deps = makeDeps({ audit: makeAudit(auditEntries) })
+    const svc = createNotificationService(deps)
+
+    const fakeClient = {
+      session: {
+        get: async () => { throw new Error("network failure") },
+      },
+    } as unknown as Parameters<typeof svc.notifySessionIdle>[0]
+
+    // Should not throw — failure is audited
+    await expect(svc.notifySessionIdle(fakeClient, "sess-throw")).resolves.toBeUndefined()
+
+    const entry = auditEntries.find(e => e.action === "telegram.send_failed")
+    expect(entry).toBeDefined()
+    expect(entry?.details.kind).toBe("session_idle")
+  })
+
+  test("telegram.send_failed is audited when session lookup throws in notifySessionError", async () => {
+    const auditEntries: AuditEntry[] = []
+    const deps = makeDeps({ audit: makeAudit(auditEntries) })
+    const svc = createNotificationService(deps)
+
+    const fakeClient = {
+      session: {
+        get: async () => { throw new Error("timeout") },
+      },
+    } as unknown as Parameters<typeof svc.notifySessionError>[0]
+
+    await expect(svc.notifySessionError(fakeClient, "sess-err", "crash")).resolves.toBeUndefined()
+
+    const entry = auditEntries.find(e => e.action === "telegram.send_failed")
+    expect(entry).toBeDefined()
+    expect(entry?.details.kind).toBe("session_error")
+  })
+})
+
+// ─── telegram fire-and-forget on permission pending ──────────────────────────
+
+describe("notifyPermissionPending — telegram called fire-and-forget", () => {
+  test("telegram.sendPermissionRequest is called even when telegram disabled", async () => {
+    // The code ALWAYS calls telegram.sendPermissionRequest (fire-and-forget .catch)
+    // regardless of telegram.enabled(). Only the RETURN VALUE of notifyPermissionPending
+    // accounts for telegram.enabled(). This tests actual behavior.
+    const telegram = makeTelegram({ enabled: false })
+    const deps = makeDeps({ telegram })
+    const svc = createNotificationService(deps)
+
+    await svc.notifyPermissionPending("perm-tg", "title", "sess", "execute")
+
+    // Fire-and-forget — give micro-tasks a tick to settle
+    await new Promise<void>(r => setTimeout(r, 10))
+
+    const called = telegram.calls.find(c => c.method === "sendPermissionRequest")
+    expect(called).toBeDefined()
+  })
+
+  test("push.broadcast is called when push.isEnabled() is true", async () => {
+    const push = makePush({ enabled: true, subscriptionCount: 0 })
+    const deps = makeDeps({ push })
+    const svc = createNotificationService(deps)
+
+    await svc.notifyPermissionPending("perm-push", "Allow write", "sess", "write")
+
+    await new Promise<void>(r => setTimeout(r, 10))
+
+    expect(push.broadcasts.length).toBeGreaterThan(0)
+  })
+
+  test("push.broadcast is NOT called when push.isEnabled() is false", async () => {
+    const push = makePush({ enabled: false })
+    const deps = makeDeps({ push })
+    const svc = createNotificationService(deps)
+
+    await svc.notifyPermissionPending("perm-no-push", "title", "sess", "execute")
+
+    await new Promise<void>(r => setTimeout(r, 10))
+
+    expect(push.broadcasts).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

Closes the **test-coverage-gap** item of #25. Four modules flagged high-risk in the v1.21.0 audit had **zero** tests; this adds 66 characterization tests covering their real behavior.

| Module | Tests | What's covered |
|--------|-------|----------------|
| `integrations/opencode/hooks/event.ts` | 11 | `sessionBusyStart` lifecycle: busy→idle under/over the 10s threshold, `session.error`, no-prior-busy safety |
| `integrations/opencode/hooks/permission.ask.ts` | 9 | **Security-critical**: remote-block vs. TUI-fallthrough decision, allow/deny/timeout/no-channel paths, audit entries |
| `integrations/opencode/hooks/tool.ts` | 23 | `tool.started`/`tool.completed`, `subagent.spawned` across all task-name variants, description/prompt fallback |
| `notifications/pipeline.ts` | 23 | fan-out, `notifyPermissionPending` true/false (drives whether the permission hook blocks), SSE reachability, channel isolation, `flush` |

## Notes

- **Tests-only. Zero production change.** Branched from clean `main` — no overlap with #26 or #27.
- Timing is deterministic (threshold tested by injecting the start timestamp, not real waits). No flaky sleeps in the hot paths.
- The characterization tests surfaced **3 latent issues** — captured as `CHARACTERIZATION:` tests asserting current behavior, **not fixed here** (scope). Documented as a comment on #25.

## Testing

- [x] `bun test` — 595 pass / 0 fail (was 529 on main; +66)
- [x] `tsc --noEmit` — clean
- [x] No `any`, no `@ts-ignore`, follows the `codex/handlers.test.ts` house style

Refs #25 (partial). Does not close #25 — remaining items (constants relocate, system.ts split, AgentIntegration port decision) stay open there.
