### PR TITLE
docs(integrations): make AgentIntegration port describe reality

### DIFF
--- a/src/integrations/opencode/index.ts
+++ b/src/integrations/opencode/index.ts
@@ -63,6 +63,8 @@ export type OpenCodeSetupDeps = {
   audit: AuditLog
 }
 
+// Intentional outlier: this does NOT implement the `AgentIntegration` port
+// (../ports.ts) — native-SDK shape, see the SDK injection-shape note above.
 export const opencodeIntegration = {
   name: 'opencode' as const,
 

--- a/src/integrations/ports.ts
+++ b/src/integrations/ports.ts
@@ -1,9 +1,23 @@
 // ─── Integration port ─────────────────────────────────────────────────────────
-// The contract honored by every external agent integration (OpenCode native
-// hooks, Codex HTTP bridge, and any future integration — Cursor, Aider).
+// `AgentIntegration` models the HTTP-route-bridged CLI integration contract:
+// a `setup(IntegrationDeps)` that registers routes/hooks imperatively and
+// returns an `IntegrationHandle`. It is honored by `codexIntegration`
+// (integrations/codex/index.ts) and by any future integration that exposes an
+// imperative registration API (Cursor, Aider).
 //
-// `AgentIntegration` is one of two explicit ports in the architecture. See
+// It is one of two explicit ports in the architecture. See
 // docs/REFACTOR-2026-04-architecture.md §Ports for design rationale.
+//
+// Intentional outlier — `opencodeIntegration` does NOT implement this port.
+// The OpenCode SDK plugin model has no imperative hook-registration API: the
+// plugin must RETURN a Hooks object, so `opencodeIntegration.setup()` takes a
+// wider `OpenCodeSetupDeps` and returns `OpenCodeIntegrationHandle` (hooks +
+// shutdown) instead of conforming to `AgentIntegration`. This is a native-SDK
+// integration, not an HTTP-bridged one — forcing it behind this port would
+// mean optional deps no other integration uses (a false abstraction). The
+// shared seam is `IntegrationHandle` (the shutdown contract), which
+// `OpenCodeIntegrationHandle` does extend. Full rationale and the SDK
+// injection-shape spike result live in integrations/opencode/index.ts.
 
 import type { PermissionQueue } from '../core/permissions/queue'
 import type { EventBus } from '../core/events/bus'


### PR DESCRIPTION
## Summary

Resolves the **"`AgentIntegration` port doesn't describe reality"** item of #25.

`ports.ts` claimed the port was "honored by every external agent integration (OpenCode native hooks, Codex HTTP bridge, ...)". **False** — only `codexIntegration` implements it (`codex/index.ts:9` `createCodexIntegration(): AgentIntegration`). `opencodeIntegration` is an untyped object literal with `setup(deps: OpenCodeSetupDeps): OpenCodeIntegrationHandle` — a wider, non-conforming shape, because the OpenCode SDK plugin model has no imperative hook-registration API (the plugin must *return* a `Hooks` object).

## Decision

The audit suggested "add `notifications`/`sessionBusyStart`/`client` as optional fields to `IntegrationDeps` and type `opencodeIntegration` as `AgentIntegration`". **Rejected.** Optional fields that only one of two integrations ever uses don't make the port honest — they make it lie more quietly while adding a fat interface. The wrong abstraction costs more than honest duplication.

Chosen instead: **make the port tell the truth.**

- `AgentIntegration` now documents that it models the **HTTP-route-bridged CLI integration** contract (honored by `codexIntegration`, and any future imperative-registration integration).
- `opencodeIntegration` is documented as an **intentional native-SDK outlier** that does not implement the port, with the SDK rationale and a pointer to the in-depth note in `opencode/index.ts`.
- The genuine shared seam — `IntegrationHandle` (shutdown) — is called out; `OpenCodeIntegrationHandle` does extend it.
- One back-reference line added at the `opencodeIntegration` definition site.

## Changes

- `src/integrations/ports.ts` — header + port scope rewritten to match reality.
- `src/integrations/opencode/index.ts` — one-line cross-reference.

## Testing

- [x] **Docs/comments only — zero behavior change.**
- [x] `tsc --noEmit` clean
- [x] `bun test` 529/0 (branch off clean `main`)
- [x] No conflict with #26/#27/#28 (disjoint files) — mergeable in any order

Refs #25 (partial). Does not close #25 — constants relocate (task 7) and `system.ts` split (task 8) stay open there, blocked on #26 merging.
