### PR TITLE
refactor(architecture): relocate transport constants out of server/

### DIFF
--- a/src/infra/http/constants.ts
+++ b/src/infra/http/constants.ts
@@ -31,3 +31,18 @@ export const DEFAULT_PORT = 4097
  *  LAN (phone, second laptop) without the user needing to set PILOT_HOST.
  *  Every endpoint still requires a Bearer token. */
 export const DEFAULT_HOST = "0.0.0.0"
+
+/** Maximum response body size when proxying session attachments (2 MiB).
+ *  Matches READ_MAX_BYTES used by readFileAbs in system.ts. */
+export const ATTACHMENT_MAX_BYTES = 2 * 1024 * 1024
+
+/** MIME types allowed through the attachment proxy endpoint.
+ *  SVG is allowed only via <img> (never injected as innerHTML — see dashboard renderer).
+ *  Video, audio, PDF etc. are explicitly excluded for this v1 surface. */
+export const MIME_SAFELIST = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/svg+xml",
+] as const

--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -7,7 +7,8 @@ import {
   resolveSources,
   RESTART_REQUIRED_FIELDS,
 } from "./config"
-import { DEFAULT_HOST, DEFAULT_CODEX_PERMISSION_TIMEOUT_MS, DEFAULT_PERMISSION_TIMEOUT_MS, DEFAULT_PORT, MAX_CODEX_PERMISSION_TIMEOUT_MS } from "./constants"
+import { DEFAULT_CODEX_PERMISSION_TIMEOUT_MS, DEFAULT_PERMISSION_TIMEOUT_MS, MAX_CODEX_PERMISSION_TIMEOUT_MS } from "./constants"
+import { DEFAULT_HOST, DEFAULT_PORT } from "../infra/http/constants"
 
 describe("loadConfig", () => {
   test("returns defaults when env is empty", () => {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -14,7 +14,8 @@
 // in process.env, so config resolution passes the original shell snapshot
 // separately (`shellEnv`) to distinguish the two.
 
-import { DEFAULT_CODEX_PERMISSION_TIMEOUT_MS, DEFAULT_HOST, DEFAULT_PERMISSION_TIMEOUT_MS, DEFAULT_PORT, DEFAULT_PROJECT_STATE_MODE, MAX_CODEX_PERMISSION_TIMEOUT_MS, VAPID_DEFAULT_SUBJECT } from "./constants"
+import { DEFAULT_CODEX_PERMISSION_TIMEOUT_MS, DEFAULT_PERMISSION_TIMEOUT_MS, DEFAULT_PROJECT_STATE_MODE, MAX_CODEX_PERMISSION_TIMEOUT_MS } from "./constants"
+import { DEFAULT_HOST, DEFAULT_PORT, VAPID_DEFAULT_SUBJECT } from "../infra/http/constants"
 import type { PilotSettings } from "../core/settings/store"
 
 // Re-export types from their canonical locations in core/ and infra/.

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -1,62 +1,31 @@
-// ─── Shared constants ────────────────────────────────────────────────────────
-// Single source of truth for magic numbers and version strings.
+// ─── Server / composition-root constants ─────────────────────────────────────
+// Only constants that are EXCLUSIVELY used here at the composition root,
+// or that have a hard external reference (e.g. PILOT_VERSION is read by the
+// asset-sanity test via readFileSync — do NOT move it).
+//
+// HTTP-transport constants (MAX_REQUEST_BODY_BYTES, HTTP_STATUS,
+// BUN_SERVE_IDLE_TIMEOUT_SEC, LOCALHOST_ADDRESSES, VAPID_DEFAULT_SUBJECT,
+// DEFAULT_PORT, DEFAULT_HOST) live in src/infra/http/constants.ts.
+//
+// Tunnel constants (TUNNEL_START_TIMEOUT_MS, TUNNEL_KILL_GRACE_MS,
+// TUNNEL_URL_PATTERNS) live in src/infra/tunnel/constants.ts.
+//
+// Telegram constants (TELEGRAM_ERROR_MAX_CHARS) live in
+// src/notifications/channels/telegram/constants.ts.
+//
+// Attachment proxy constants (ATTACHMENT_MAX_BYTES, MIME_SAFELIST) live in
+// src/infra/http/constants.ts.
 
 export const PILOT_VERSION = "1.21.0"
-export const DEFAULT_PORT = 4097
-// Default host: `0.0.0.0` so the dashboard is immediately reachable from LAN
-// (phone, second laptop) without the user needing to discover the host
-// setting. Every HTTP endpoint still requires a Bearer token, so this widens
-// the network surface but NOT the auth surface — an attacker on the same
-// network still needs the generated token (printed in the `/remote` banner
-// and embedded in the QR code) to do anything. Users who want the stricter
-// localhost-only bind can set `PILOT_HOST=127.0.0.1` in the .env or in the
-// Settings modal's Connection tab.
-export const DEFAULT_HOST = "0.0.0.0"
 export const DEFAULT_PERMISSION_TIMEOUT_MS = 300_000
 export const SSE_KEEPALIVE_INTERVAL_MS = 25_000
-export const BUN_SERVE_IDLE_TIMEOUT_SEC = 255
-
-export const LOCALHOST_ADDRESSES = ["127.0.0.1", "localhost", "::1", "0.0.0.0"] as const
-export const VAPID_DEFAULT_SUBJECT = "mailto:admin@opencode-pilot.local"
-export const TUNNEL_START_TIMEOUT_MS = 20_000
-export const TUNNEL_KILL_GRACE_MS = 400
 export const TOAST_DURATION_MS = 5_000
 export const TOAST_PROMOTION_DURATION_MS = 7_000
 export const PROMOTION_POLL_INTERVAL_MS = 500
-export const TELEGRAM_ERROR_MAX_CHARS = 500
-export const TUNNEL_URL_PATTERNS = {
-  cloudflared: /https:\/\/[a-z0-9-]+\.trycloudflare\.com/,
-  ngrok: /https:\/\/[a-z0-9-]+\.ngrok(-free)?\.app/,
-} as const
-export const HTTP_STATUS = {
-  OK: 200, CREATED: 201, NO_CONTENT: 204,
-  BAD_REQUEST: 400, UNAUTHORIZED: 401, FORBIDDEN: 403, NOT_FOUND: 404,
-  CONFLICT: 409, PAYLOAD_TOO_LARGE: 413, INTERNAL: 500, UNAVAILABLE: 503,
-} as const
-
-/** Maximum accepted request body size (1 MiB). Requests with a larger
- *  Content-Length header, or whose streamed body exceeds this, are rejected
- *  with 413 Payload Too Large. */
-export const MAX_REQUEST_BODY_BYTES = 1_048_576 // 1 MiB
 
 /** Default project-state write mode: write per-project files only when
  *  `.opencode/` already exists (opt-in via `always`, disable via `off`). */
 export const DEFAULT_PROJECT_STATE_MODE = "auto" as const
-
-/** Maximum response body size when proxying session attachments (2 MiB).
- *  Matches READ_MAX_BYTES used by readFileAbs in system.ts. */
-export const ATTACHMENT_MAX_BYTES = 2 * 1024 * 1024
-
-/** MIME types allowed through the attachment proxy endpoint.
- *  SVG is allowed only via <img> (never injected as innerHTML — see dashboard renderer).
- *  Video, audio, PDF etc. are explicitly excluded for this v1 surface. */
-export const MIME_SAFELIST = [
-  "image/png",
-  "image/jpeg",
-  "image/gif",
-  "image/webp",
-  "image/svg+xml",
-] as const
 
 /** Maximum safe value for PILOT_CODEX_PERMISSION_TIMEOUT_MS.
  *  Bun's idleTimeout cap is 255s. Any codex permission timeout ≥255s would

--- a/src/transport/http/handlers/sessions.ts
+++ b/src/transport/http/handlers/sessions.ts
@@ -9,7 +9,7 @@ import {
 import { extractDirectory } from "./system"
 import { validateToken, safeEqual } from "../middlewares/auth"
 import { validateEndpoint } from "../../../infra/network/ssrf"
-import { ATTACHMENT_MAX_BYTES, MIME_SAFELIST } from "../../../server/constants"
+import { ATTACHMENT_MAX_BYTES, MIME_SAFELIST } from "../../../infra/http/constants"
 import type { FilePart } from "@opencode-ai/sdk"
 
 export async function listSessions({ url, deps }: RouteContext): Promise<Response> {


### PR DESCRIPTION
## Summary

Resolves the **dependency-rule inversion** item of #25 (the audit's "CRITICAL" layering finding).

`src/transport/http/handlers/sessions.ts` imported `ATTACHMENT_MAX_BYTES` / `MIME_SAFELIST` from `server/constants` — a lower layer (`transport/`) reaching into the composition root (`server/`), inverting `infra/ ← core/ ← transport/ ← server/index.ts`.

## ⚠️ Stacked PR

**Base is `fix/security-hardening-token-ssrf` (#26), not `main`.** This branch modifies `sessions.ts`, which #26 also changed; stacking avoids a merge conflict. **Merge order: #26 → this.** If #26 changes in review, this rebases.

## Changes (pure refactor — zero behavior change)

- `ATTACHMENT_MAX_BYTES`, `MIME_SAFELIST` → `infra/http/constants.ts` (alongside `MAX_REQUEST_BODY_BYTES`, which is there for exactly this reason).
- Deleted 11 duplicated/orphan constants from `server/constants.ts` — canonical copies already lived in `infra/http/constants.ts`, `infra/tunnel/constants.ts`, `notifications/channels/telegram/constants.ts`.
- Repointed `server/config.ts` + `config.test.ts` to the `infra` locations.
- `server/constants.ts` now holds only `PILOT_VERSION` (hard-referenced by the release script / `asset-sanity.test.ts`) plus genuinely composition-root-specific symbols, with header comments documenting each canonical home.

Constant values are byte-identical. Every duplicate/orphan claim was **verified against its actual importers before deletion** — no discrepancies found, no claimed orphan turned out to be in use.

## Verification

- [x] `bunx tsc --noEmit` clean
- [x] `bun test` 558/0 (stacked base; matches #26's count)
- [x] Architectural goal confirmed: `rg "from .*server/constants" src/` → no cross-layer importers remain; `server/constants.ts` exports only `PILOT_VERSION`
- [x] `asset-sanity.test.ts` green (release-script `PILOT_VERSION` reference intact)

Refs #25 (partial). Does not close #25 — `system.ts` split (task 8) stays open there.
