### PR TITLE
fix(state): token rotation honors PILOT_PROJECT_STATE and never fails silently

### DIFF
--- a/src/core/state/store.test.ts
+++ b/src/core/state/store.test.ts
@@ -8,7 +8,7 @@
 //    activatePrimary can surface silent FS errors to ctx.client.app.log.
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test"
-import { mkdtempSync, rmSync, existsSync, writeFileSync } from "fs"
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync } from "fs"
 import { tmpdir, homedir } from "os"
 import { join } from "path"
 import { writeState, readState, readGlobalState, clearState, globalStatePath } from "./store"
@@ -288,5 +288,153 @@ describe("writeState WriteStateResult — failure isolation (1.13.13)", () => {
     // drift breaks cross-module contract without a type error.
     expect(globalStatePath().startsWith(homedir())).toBe(true)
     expect(globalStatePath().endsWith(join(".opencode-pilot", "pilot-state.json"))).toBe(true)
+  })
+})
+
+// ── Batch 6: updateStateToken — mode forwarding + structured result ───────────
+// TDD: these tests are written BEFORE the implementation is changed.
+// They describe the two bugs being fixed:
+//   Bug 1: mode ignored — updateStateToken always passed mode="auto" to writeState.
+//   Bug 2: silent skip — when readState returns null, updateStateToken was a void
+//          no-op with no structured result the caller could inspect.
+
+import { updateStateToken } from "./store"
+import type { UpdateTokenResult } from "./store"
+
+describe("updateStateToken — mode forwarding (bug 1)", () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = tempDir()
+  })
+
+  afterEach(() => {
+    try { rmSync(dir, { recursive: true, force: true }) } catch {}
+  })
+
+  test("mode=off + .opencode/ exists: no project file written after token update", () => {
+    // Seed a state so readState returns a result (not null).
+    const opencodedir = join(dir, ".opencode")
+    mkdirSync(opencodedir, { recursive: true })
+    const seedState: PilotState = { token: "old", port: 4097, host: "127.0.0.1", startedAt: 1, pid: process.pid }
+    writeState(dir, seedState, "always")
+
+    // Now rotate token with mode=off. Even though .opencode/ exists, the project
+    // file must NOT be touched (or created) when mode=off.
+    const result = updateStateToken(dir, "new-token", "off")
+
+    // Must return ok:true (existing state was found).
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      // Global must have been updated with new token.
+      expect(result.write.global.ok).toBe(true)
+      // Project must be null (skipped by mode=off) — not ok:false.
+      expect(result.write.project).toBeNull()
+    }
+    // The project file must NOT reflect the new token if it was re-written.
+    // (mode=off should have passed through to writeState which skips project writes)
+    const projectFilePath = join(dir, ".opencode", "pilot-state.json")
+    if (existsSync(projectFilePath)) {
+      const content = JSON.parse(readFileSync(projectFilePath, "utf-8")) as PilotState
+      // If the file exists (from seed), it must NOT have been updated with the new token
+      // because mode=off suppresses project writes.
+      // NOTE: The seed wrote with mode=always so the file exists. After updateStateToken
+      // with mode=off, the token in the project file must remain "old".
+      expect(content.token).not.toBe("new-token")
+    }
+  })
+
+  test("mode=auto + .opencode/ exists: project file IS updated", () => {
+    const opencodedir = join(dir, ".opencode")
+    mkdirSync(opencodedir, { recursive: true })
+    const seedState: PilotState = { token: "old", port: 4097, host: "127.0.0.1", startedAt: 1, pid: process.pid }
+    writeState(dir, seedState, "auto")
+
+    const result = updateStateToken(dir, "rotated", "auto")
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.write.global.ok).toBe(true)
+      expect(result.write.project).not.toBeNull()
+      expect(result.write.project!.ok).toBe(true)
+    }
+    const projectFilePath = join(dir, ".opencode", "pilot-state.json")
+    const content = JSON.parse(readFileSync(projectFilePath, "utf-8")) as PilotState
+    expect(content.token).toBe("rotated")
+  })
+
+  test("mode=always: project file written even without pre-existing .opencode/", () => {
+    // Seed state only in the global file (no .opencode/ dir).
+    const seedState: PilotState = { token: "seed", port: 4097, host: "127.0.0.1", startedAt: 1, pid: process.pid }
+    // Write global-only by skipping project (mode=off), then verify auto-create via always.
+    writeState(dir, seedState, "off")
+
+    const result = updateStateToken(dir, "always-token", "always")
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.write.project).not.toBeNull()
+      expect(result.write.project!.ok).toBe(true)
+    }
+    const projectFilePath = join(dir, ".opencode", "pilot-state.json")
+    expect(existsSync(projectFilePath)).toBe(true)
+    const content = JSON.parse(readFileSync(projectFilePath, "utf-8")) as PilotState
+    expect(content.token).toBe("always-token")
+  })
+})
+
+describe("updateStateToken — null readState path (bug 2)", () => {
+  let dir: string
+  // XDG isolation: save and restore XDG_STATE_HOME so the global state path
+  // points at an empty temp dir — this forces readState to return null
+  // deterministically regardless of any real ~/.opencode-pilot/pilot-state.json.
+  let xdgDir: string
+  let prevXdg: string | undefined
+
+  beforeEach(() => {
+    dir = tempDir()
+    // globalStatePath() → stateFile() → getPluginStateDir() → XDG_STATE_HOME
+    xdgDir = mkdtempSync(join(tmpdir(), "pilot-xdg-state-"))
+    prevXdg = process.env.XDG_STATE_HOME
+    process.env.XDG_STATE_HOME = xdgDir
+  })
+
+  afterEach(() => {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_STATE_HOME
+    } else {
+      process.env.XDG_STATE_HOME = prevXdg
+    }
+    try { rmSync(dir, { recursive: true, force: true }) } catch {}
+    try { rmSync(xdgDir, { recursive: true, force: true }) } catch {}
+  })
+
+  test("readState null → returns { ok: false, reason: 'no-existing-state' }", () => {
+    // dir is a fresh empty tempdir with no .opencode/ subdirectory.
+    // XDG_STATE_HOME points at a fresh empty tempdir so globalStatePath()
+    // resolves to a file that does not exist.
+    // Both safeRead calls inside readState() return null → updateStateToken
+    // must return { ok: false, reason: "no-existing-state" }.
+    const result = updateStateToken(dir, "new-token", "auto")
+    expect(result).toEqual({ ok: false, reason: "no-existing-state" })
+  })
+
+  test("UpdateTokenResult type contract: ok:false shape has reason field", () => {
+    // This is a compile-time + runtime shape test.
+    const notOk: UpdateTokenResult = { ok: false, reason: "no-existing-state" }
+    expect(notOk.ok).toBe(false)
+    expect(notOk.reason).toBe("no-existing-state")
+  })
+
+  test("UpdateTokenResult type contract: ok:true shape has write.global", () => {
+    // Seed via writeState so readState finds it through the global fallback.
+    const seedState: PilotState = { token: "tok", port: 4097, host: "127.0.0.1", startedAt: 1, pid: process.pid }
+    writeState(dir, seedState, "off") // writes global only (into xdgDir via XDG_STATE_HOME)
+    // readState(dir) will fall back to global → returns a state
+    const result = updateStateToken(dir, "updated", "off")
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.write.global.ok).toBe(true)
+    }
   })
 })

--- a/src/core/state/store.ts
+++ b/src/core/state/store.ts
@@ -129,15 +129,37 @@ export function writeState(
 }
 
 /**
- * Update the token in an existing state file (used by token rotation).
- * If the state file doesn't exist, creates it with the new token and the
- * provided fallback values.
+ * Structured result from {@link updateStateToken}.
+ * `ok: false` means no existing state was found (readState returned null) —
+ * the caller is responsible for logging a visible diagnostic; core/ does not log.
+ * `ok: true` wraps the WriteStateResult from the underlying writeState call.
  */
-export function updateStateToken(directory: string, newToken: string): void {
+export type UpdateTokenResult =
+  | { ok: true; write: WriteStateResult }
+  | { ok: false; reason: "no-existing-state" }
+
+/**
+ * Update the token in an existing state file (used by token rotation).
+ *
+ * - Passes `mode` through to {@link writeState} so the user's PILOT_PROJECT_STATE
+ *   setting is respected (fixes the "mode ignored" bug).
+ * - Returns a structured {@link UpdateTokenResult} instead of `void` so callers
+ *   can surface a visible diagnostic when readState returns null (fixes the
+ *   "silent skip" bug per AGENTS.md §"No silent failures").
+ *
+ * Core/ does NOT log here — logging is the caller's responsibility (transport/).
+ */
+export function updateStateToken(
+  directory: string,
+  newToken: string,
+  mode: ProjectStateMode = "auto",
+): UpdateTokenResult {
   const existing = readState(directory)
-  if (existing) {
-    writeState(directory, { ...existing, token: newToken })
+  if (!existing) {
+    return { ok: false, reason: "no-existing-state" }
   }
+  const write = writeState(directory, { ...existing, token: newToken }, mode)
+  return { ok: true, write }
 }
 
 export function readState(directory: string): PilotState | null {

--- a/src/transport/http/handlers/system.test.ts
+++ b/src/transport/http/handlers/system.test.ts
@@ -1,0 +1,322 @@
+// system.test.ts — Unit tests for rotateAuthToken handler
+// TDD: these tests were written BEFORE the implementation was changed.
+//
+// Two bugs being fixed:
+//   Bug 1: mode ignored — updateStateToken always passed mode="auto", ignoring
+//          PILOT_PROJECT_STATE. If mode="off" and .opencode/ exists, token rotation
+//          could still create or update the project file.
+//   Bug 2: silent skip — when readState returns null (state deleted mid-session),
+//          updateStateToken was a no-op and rotateAuthToken had no visibility.
+//          The TUI /remote command would then use the OLD token from pilot-state.json.
+//
+// These tests use a real temp-dir for the filesystem assertions and stub
+// audit/logger to verify the observable side-effect (structured log/audit call)
+// on persist failure.
+
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test"
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import type { AuditLog } from "../../../core/audit/log"
+import type { Logger } from "../../../infra/logger/index"
+import { writeState, globalStatePath } from "../../../core/state/store"
+import type { PilotState } from "../../../core/state/store"
+import type { RouteDeps } from "../routes"
+import type { Config } from "../../../core/types/config"
+import type { PluginInput } from "@opencode-ai/plugin"
+import { createEventBus } from "../../../core/events/bus"
+import { createPermissionQueue } from "../../../core/permissions/queue"
+import { createTelegramChannel } from "../../../notifications/channels/telegram/index"
+import { createPushService } from "../../../notifications/channels/push/service"
+import { rotateAuthToken } from "./system"
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "pilot-rotate-test-"))
+}
+
+interface SpyAuditLog extends AuditLog {
+  calls: Array<{ action: string; details: Record<string, unknown> }>
+}
+
+function createSpyAudit(): SpyAuditLog {
+  const calls: Array<{ action: string; details: Record<string, unknown> }> = []
+  return {
+    calls,
+    log(action: string, details: Record<string, unknown>) {
+      calls.push({ action, details })
+    },
+  }
+}
+
+interface SpyLogger extends Logger {
+  warnCalls: Array<unknown[]>
+  errorCalls: Array<unknown[]>
+}
+
+function createSpyLogger(): SpyLogger {
+  const warnCalls: Array<unknown[]> = []
+  const errorCalls: Array<unknown[]> = []
+  return {
+    warnCalls,
+    errorCalls,
+    debug: () => {},
+    info: () => {},
+    warn: (...args: unknown[]) => { warnCalls.push(args) },
+    error: (...args: unknown[]) => { errorCalls.push(args) },
+  }
+}
+
+function buildConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    port: 4097,
+    host: "127.0.0.1",
+    permissionTimeoutMs: 5_000,
+    tunnel: "off",
+    telegram: null,
+    dev: false,
+    vapid: null,
+    enableGlobOpener: false,
+    fetchTimeoutMs: 10_000,
+    projectStateMode: "auto",
+    codexPermissionTimeoutMs: 300_000,
+    ...overrides,
+  }
+}
+
+function buildDeps(
+  directory: string,
+  config: Config,
+  audit: AuditLog,
+  logger: Logger,
+): RouteDeps {
+  const eventBus = createEventBus()
+  const permissionQueue = createPermissionQueue(5_000)
+  const codexPermissionQueue = createPermissionQueue(300_000)
+  const telegram = createTelegramChannel(null, permissionQueue, codexPermissionQueue)
+  const push = createPushService({ config, audit, logger })
+
+  const deps: RouteDeps = {
+    client: {
+      session: {
+        list: async () => ({ data: [], error: null }),
+        status: async () => ({ data: {}, error: null }),
+      },
+      app: {
+        log: async () => ({ data: { ok: true }, error: null }),
+        agents: async () => ({ data: [], error: null }),
+      },
+    } as unknown as PluginInput["client"],
+    project: { worktree: directory } as unknown as PluginInput["project"],
+    directory,
+    worktree: directory as unknown as PluginInput["worktree"],
+    config,
+    token: "initial-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    rotateToken(newToken: string) {
+      deps.token = newToken
+    },
+    tunnelUrl: null,
+    audit,
+    eventBus,
+    permissionQueue,
+    codexPermissionQueue,
+    telegram,
+    push,
+    logger,
+    settingsStore: {
+      load: () => ({}),
+      save: () => ({}),
+      reset: () => {},
+      filePath: () => "/tmp/pilot-rotate-test-config.json",
+    } as unknown as RouteDeps["settingsStore"],
+    shellEnv: {},
+    envFileApplied: [],
+    pilotVersion: "0.0.0-test",
+    settingsLoader: {
+      loadEffective: () => ({
+        effective: config,
+        settings: {
+          port: config.port,
+          host: config.host,
+          permissionTimeoutMs: config.permissionTimeoutMs,
+          tunnel: config.tunnel,
+          telegramToken: "",
+          telegramChatId: "",
+          vapidPublicKey: "",
+          vapidPrivateKey: "",
+          vapidSubject: "",
+          enableGlobOpener: config.enableGlobOpener,
+          fetchTimeoutMs: config.fetchTimeoutMs,
+          projectStateMode: config.projectStateMode,
+          hookTokenConfigured: false,
+        },
+        sources: {},
+      }),
+      envKeyFor: () => "",
+      restartRequiredFields: [],
+    },
+  }
+  return deps
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("rotateAuthToken — mode forwarded to updateStateToken (bug 1)", () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = tempDir()
+  })
+
+  afterEach(() => {
+    try { rmSync(dir, { recursive: true, force: true }) } catch {}
+  })
+
+  test("mode=off + .opencode/ exists: project file NOT updated after rotation", async () => {
+    // Seed state with mode=always so a project file exists.
+    const opencodedir = join(dir, ".opencode")
+    mkdirSync(opencodedir, { recursive: true })
+    const seedState: PilotState = {
+      token: "old-token",
+      port: 4097,
+      host: "127.0.0.1",
+      startedAt: 1,
+      pid: process.pid,
+    }
+    writeState(dir, seedState, "always")
+
+    const config = buildConfig({ projectStateMode: "off" })
+    const audit = createSpyAudit()
+    const logger = createSpyLogger()
+    const deps = buildDeps(dir, config, audit, logger)
+
+    const ctx = { deps, params: {}, url: new URL("http://127.0.0.1/auth/rotate"), req: new Request("http://127.0.0.1/auth/rotate", { method: "POST" }) }
+    const resp = await rotateAuthToken(ctx)
+
+    // Handler must still return 200.
+    expect(resp.status).toBe(200)
+
+    // The project file must NOT have been updated — token in it should still be "old-token".
+    const projectFilePath = join(dir, ".opencode", "pilot-state.json")
+    expect(existsSync(projectFilePath)).toBe(true) // file existed from seed
+    const content = JSON.parse(readFileSync(projectFilePath, "utf-8")) as PilotState
+    // With mode=off, updateStateToken must not write to the project file.
+    expect(content.token).toBe("old-token")
+  })
+
+  test("mode=auto + .opencode/ exists: project file IS updated", async () => {
+    const opencodedir = join(dir, ".opencode")
+    mkdirSync(opencodedir, { recursive: true })
+    const seedState: PilotState = {
+      token: "old-token",
+      port: 4097,
+      host: "127.0.0.1",
+      startedAt: 1,
+      pid: process.pid,
+    }
+    writeState(dir, seedState, "auto")
+
+    const config = buildConfig({ projectStateMode: "auto" })
+    const audit = createSpyAudit()
+    const logger = createSpyLogger()
+    const deps = buildDeps(dir, config, audit, logger)
+
+    const ctx = { deps, params: {}, url: new URL("http://127.0.0.1/auth/rotate"), req: new Request("http://127.0.0.1/auth/rotate", { method: "POST" }) }
+    const resp = await rotateAuthToken(ctx)
+
+    expect(resp.status).toBe(200)
+
+    const body = await resp.json() as { token: string }
+    const newToken: string = body.token
+
+    // Project file MUST have the new token.
+    const projectFilePath = join(dir, ".opencode", "pilot-state.json")
+    const content = JSON.parse(readFileSync(projectFilePath, "utf-8")) as PilotState
+    expect(content.token).toBe(newToken)
+  })
+})
+
+describe("rotateAuthToken — readState null → visible failure (bug 2)", () => {
+  // XDG isolation: redirect XDG_STATE_HOME so globalStatePath() resolves into a
+  // fresh empty temp dir. Combined with a fresh project dir that has no .opencode/,
+  // this forces readState → null DETERMINISTICALLY across all tests in this block.
+  let dir: string
+  let xdgDir: string
+  let prevXdg: string | undefined
+
+  beforeEach(() => {
+    dir = tempDir()
+    // getPluginStateDir() checks XDG_STATE_HOME first (src/infra/paths/index.ts:28-29)
+    xdgDir = mkdtempSync(join(tmpdir(), "pilot-xdg-state-"))
+    prevXdg = process.env.XDG_STATE_HOME
+    process.env.XDG_STATE_HOME = xdgDir
+  })
+
+  afterEach(() => {
+    if (prevXdg === undefined) {
+      delete process.env.XDG_STATE_HOME
+    } else {
+      process.env.XDG_STATE_HOME = prevXdg
+    }
+    try { rmSync(dir, { recursive: true, force: true }) } catch {}
+    try { rmSync(xdgDir, { recursive: true, force: true }) } catch {}
+  })
+
+  test("no existing state → audit call with persist_failed action (unconditional)", async () => {
+    // dir is a fresh empty tempdir (no .opencode/).
+    // XDG_STATE_HOME is an empty tempdir → globalStatePath() points at a
+    // non-existent file. readState(dir) returns null → updateStateToken → ok:false.
+    // The handler MUST still return HTTP 200 (in-memory rotation succeeds),
+    // fire "auth.token.rotated", AND fire "auth.token.rotated.persist_failed".
+    const config = buildConfig({ projectStateMode: "auto" })
+    const audit = createSpyAudit()
+    const logger = createSpyLogger()
+    const deps = buildDeps(dir, config, audit, logger)
+
+    const ctx = { deps, params: {}, url: new URL("http://127.0.0.1/auth/rotate"), req: new Request("http://127.0.0.1/auth/rotate", { method: "POST" }) }
+    const resp = await rotateAuthToken(ctx)
+
+    // HTTP 200 always — in-memory rotation + SSE are the primary success path.
+    expect(resp.status).toBe(200)
+
+    // auth.token.rotated MUST always fire (in-memory rotation succeeded).
+    expect(audit.calls.some(c => c.action === "auth.token.rotated")).toBe(true)
+
+    // persist_failed MUST fire unconditionally — readState returns null.
+    expect(audit.calls.some(c => c.action === "auth.token.rotated.persist_failed")).toBe(true)
+
+    // logger.warn (or error) MUST have been called — the handler logs the persist failure.
+    expect(logger.warnCalls.length + logger.errorCalls.length).toBeGreaterThan(0)
+  })
+
+  test("forced persist failure: rotateToken fired + SSE token updated in response", async () => {
+    // Same isolation as above. Verifies in-memory side-effects are not blocked by
+    // the persist failure: deps.token is updated and the response body carries the
+    // new token.
+    const config = buildConfig({ projectStateMode: "auto" })
+    const audit = createSpyAudit()
+    const logger = createSpyLogger()
+    const deps = buildDeps(dir, config, audit, logger)
+    const initialToken = deps.token
+
+    const ctx = { deps, params: {}, url: new URL("http://127.0.0.1/auth/rotate"), req: new Request("http://127.0.0.1/auth/rotate", { method: "POST" }) }
+    const resp = await rotateAuthToken(ctx)
+
+    expect(resp.status).toBe(200)
+
+    // The in-memory token must have been rotated (deps.rotateToken was called).
+    expect(deps.token).not.toBe(initialToken)
+
+    // The response body must carry the new token.
+    const body = await resp.json() as { token: string }
+    expect(body.token).toBe(deps.token)
+
+    // persist_failed path: both audit actions must be present.
+    expect(audit.calls.some(c => c.action === "auth.token.rotated")).toBe(true)
+    expect(audit.calls.some(c => c.action === "auth.token.rotated.persist_failed")).toBe(true)
+
+    // logger.warn must have been called — no silent failures.
+    expect(logger.warnCalls.length + logger.errorCalls.length).toBeGreaterThan(0)
+  })
+})

--- a/src/transport/http/handlers/system.ts
+++ b/src/transport/http/handlers/system.ts
@@ -195,7 +195,36 @@ export async function rotateAuthToken({ deps }: RouteContext): Promise<Response>
   deps.rotateToken(newToken)
 
   // Persist to state file so the TUI slash command still works after rotation.
-  updateStateToken(deps.directory, newToken)
+  // Pass projectStateMode so PILOT_PROJECT_STATE=off is respected (bug 1: mode
+  // was previously hardcoded to "auto").
+  const persistResult = updateStateToken(deps.directory, newToken, deps.config.projectStateMode)
+
+  // Observe persist failures — per AGENTS.md §"No silent failures".
+  // HTTP 200 is still returned: in-memory rotation + SSE broadcast are the
+  // primary success path; persistence is best-effort but MUST be visible.
+  if (!persistResult.ok) {
+    // Bug 2: previously a silent no-op when readState returned null.
+    const reason = persistResult.reason
+    deps.logger.warn(
+      `[opencode-pilot] rotateAuthToken: state not persisted — ${reason}. ` +
+        "TUI /remote command may use the old token until the server restarts.",
+    )
+    deps.audit.log("auth.token.rotated.persist_failed", { reason })
+  } else {
+    // Even on ok:true, surface individual write failures (global is critical).
+    const { write } = persistResult
+    if (!write.global.ok) {
+      deps.logger.warn(
+        `[opencode-pilot] rotateAuthToken: global state write failed — ` +
+          `${write.global.error}. TUI /remote command may use the old token.`,
+      )
+      deps.audit.log("auth.token.rotated.persist_failed", {
+        reason: "global-write-failed",
+        error: write.global.error,
+        path: write.global.path,
+      })
+    }
+  }
 
   deps.audit.log("auth.token.rotated", {})
 


### PR DESCRIPTION
## Summary

Resolves the **Tier-1 state/token** item of #33 (second-wave audit). Verified by hand and convergent across two independent review passes (domain-logic + silent-failures).

`updateStateToken` (`core/state/store.ts`) had two defects:

1. **Mode ignored** — called `writeState` with the default `mode="auto"`, ignoring `PILOT_PROJECT_STATE`. With `off` + an existing `.opencode/`, a token rotation could create the project `pilot-state.json` the user explicitly opted out of.
2. **Silent skip** — `if (existing)` with no else/log. When `readState` returned `null` (state file deleted/unreadable mid-session), rotation returned **200**, updated the in-memory token, broadcast SSE — but the **persisted state kept the old token**, so the TUI `/remote` later served a dead URL. Invisible, violating AGENTS.md §"No silent failures".

## Fix (core/ stays pure — observability at the boundary)

- `updateStateToken(dir, token, mode = "auto"): UpdateTokenResult` — threads `mode` into `writeState`; returns a typed discriminated result `{ ok:true; write: WriteStateResult } | { ok:false; reason:"no-existing-state" }`. No logger/HTTP import added to `core/`.
- `rotateAuthToken` passes `deps.config.projectStateMode` and inspects the result. On `no-existing-state` **or** a global write failure it emits `deps.logger.warn(...)` + `deps.audit.log("auth.token.rotated.persist_failed", { reason })`. HTTP stays **200** (in-memory rotation + SSE are the real success path) — the persistence gap is now **observable**, not silent.

## Testing

- [x] +10 tests. **Deterministic** null-path coverage: tests isolate `XDG_STATE_HOME` to a fresh temp dir (verified that's the env governing `globalStatePath()`, not `XDG_CONFIG_HOME`) so `readState`→null is forced and asserted unconditionally — not shape-only. Env restored in `afterEach`, no leak (other 624 tests unaffected).
- [x] `bun test` 634/0 · `bunx tsc --noEmit` clean
- [x] Independent fresh-context adversarial review: **APPROVE, no blocking issues** (mode-threading effective, null path observable, normal-path no regression, core purity intact).

Known follow-up (acknowledged, not blocking): the `global-write-failed` branch lacks direct coverage (needs FS-failure injection) — noted for a future test-hardening pass.

Refs #33 (Tier-1, partial — does not close; #33 tracks 6 PR groups).
