### PR TITLE
fix(transport): propagate SDK errors instead of silent 200-empty

### DIFF
--- a/src/transport/http/handlers/sdk-error-consistency.test.ts
+++ b/src/transport/http/handlers/sdk-error-consistency.test.ts
@@ -1,0 +1,517 @@
+// sdk-error-consistency.test.ts — TDD for SDK result.error handling
+// Verifies that all SDK-backed read handlers propagate SDK errors correctly
+// instead of silently returning 200 with empty data.
+//
+// Reference pattern: deleteSession (sessions.ts:112+) and postSessionPrompt.
+// Generic SDK failure → 500 SDK_ERROR + deps.logger.error called.
+// Not-found SDK error → 404 NOT_FOUND.
+// Success path → unchanged 200 with existing shape (byte-identical fallback kept).
+
+import { describe, expect, test } from "bun:test"
+import type { RouteDeps, RouteContext } from "../routes"
+import type { Logger } from "../../../infra/logger/index"
+import {
+  listSessions,
+  getSessionMessages,
+  getSessionDiff,
+  getSessionChildren,
+} from "./sessions"
+import { listTools } from "./sdk-proxy"
+import { getStatus } from "./system"
+
+// ─── Shared test fixtures ─────────────────────────────────────────────────────
+
+function makeSpyLogger(): Logger & { errorCalls: Array<[string, unknown]> } {
+  const errorCalls: Array<[string, unknown]> = []
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: (msg: string, ctx?: unknown) => { errorCalls.push([msg, ctx]) },
+    errorCalls,
+  }
+}
+
+const BASE_CONFIG: RouteDeps["config"] = {
+  port: 4097,
+  host: "127.0.0.1",
+  permissionTimeoutMs: 300_000,
+  tunnel: "off",
+  telegram: null,
+  dev: false,
+  vapid: null,
+  enableGlobOpener: false,
+  fetchTimeoutMs: 10_000,
+  projectStateMode: "auto",
+  codexPermissionTimeoutMs: 300_000,
+}
+
+const BASE_SETTINGS_LOADER: RouteDeps["settingsLoader"] = {
+  loadEffective: () => ({
+    effective: {
+      port: 4097,
+      host: "127.0.0.1",
+      permissionTimeoutMs: 300_000,
+      tunnel: "off" as const,
+      telegram: null,
+      dev: false,
+      vapid: null,
+      enableGlobOpener: false,
+      fetchTimeoutMs: 10_000,
+      projectStateMode: "auto" as const,
+      codexPermissionTimeoutMs: 300_000,
+    },
+    settings: {
+      port: 4097,
+      host: "127.0.0.1",
+      permissionTimeoutMs: 300_000,
+      tunnel: "off" as const,
+      telegramToken: "",
+      telegramChatId: "",
+      vapidPublicKey: "",
+      vapidPrivateKey: "",
+      vapidSubject: "",
+      enableGlobOpener: false,
+      fetchTimeoutMs: 10_000,
+      projectStateMode: "auto" as const,
+      hookTokenConfigured: false,
+    },
+    sources: {},
+  }),
+  envKeyFor: () => "",
+  restartRequiredFields: [],
+}
+
+function makeDeps(
+  client: Partial<RouteDeps["client"]>,
+  logger: Logger = makeSpyLogger(),
+): RouteDeps {
+  return {
+    client: client as RouteDeps["client"],
+    project: {} as RouteDeps["project"],
+    directory: "/tmp",
+    worktree: "/tmp",
+    config: BASE_CONFIG,
+    token: "tok",
+    rotateToken: () => {},
+    tunnelUrl: null,
+    audit: { log: () => {} } as RouteDeps["audit"],
+    eventBus: {
+      clientCount: () => 0,
+      emit: () => {},
+      subscribe: () => () => {},
+    } as unknown as RouteDeps["eventBus"],
+    permissionQueue: {} as RouteDeps["permissionQueue"],
+    codexPermissionQueue: {} as RouteDeps["codexPermissionQueue"],
+    telegram: { enabled: () => false } as unknown as RouteDeps["telegram"],
+    push: { isEnabled: () => false } as unknown as RouteDeps["push"],
+    logger,
+    settingsStore: {
+      load: () => ({}),
+      save: () => ({}),
+      reset: () => {},
+      filePath: () => "/tmp/c.json",
+    } as unknown as RouteDeps["settingsStore"],
+    shellEnv: {},
+    envFileApplied: [],
+    pilotVersion: "0.0.0-test",
+    settingsLoader: BASE_SETTINGS_LOADER,
+  }
+}
+
+function makeCtx(deps: RouteDeps, path = "/sessions", params: Record<string, string> = {}): RouteContext {
+  return {
+    req: new Request(`http://test${path}`),
+    url: new URL(`http://test${path}`),
+    params,
+    deps,
+  }
+}
+
+// ─── listSessions ─────────────────────────────────────────────────────────────
+
+describe("listSessions — SDK error propagation", () => {
+  test("500 + logger.error when session.list returns an error", async () => {
+    const logger = makeSpyLogger()
+    const deps = makeDeps(
+      {
+        session: {
+          list: async () => ({ data: undefined, error: { message: "IPC down" } }),
+          status: async () => ({ data: {}, error: null }),
+        } as unknown as RouteDeps["client"]["session"],
+      },
+      logger,
+    )
+    const ctx = makeCtx(deps)
+    const res = await listSessions(ctx)
+    expect(res.status).toBe(500)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("SDK_ERROR")
+    expect(logger.errorCalls.length).toBeGreaterThan(0)
+  })
+
+  test("500 + logger.error when session.status returns an error", async () => {
+    const logger = makeSpyLogger()
+    const deps = makeDeps(
+      {
+        session: {
+          list: async () => ({ data: [], error: null }),
+          status: async () => ({ data: undefined, error: { message: "IPC down" } }),
+        } as unknown as RouteDeps["client"]["session"],
+      },
+      logger,
+    )
+    const ctx = makeCtx(deps)
+    const res = await listSessions(ctx)
+    expect(res.status).toBe(500)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("SDK_ERROR")
+    expect(logger.errorCalls.length).toBeGreaterThan(0)
+  })
+
+  test("200 with correct shape when both SDK calls succeed", async () => {
+    const deps = makeDeps({
+      session: {
+        list: async () => ({ data: [{ id: "s1" }], error: null }),
+        status: async () => ({ data: { s1: "running" }, error: null }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps)
+    const res = await listSessions(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { sessions: unknown[]; statuses: Record<string, unknown> }
+    expect(body.sessions).toEqual([{ id: "s1" }])
+    expect(body.statuses).toEqual({ s1: "running" })
+  })
+
+  test("200 with empty arrays/objects when SDK returns no data but no error", async () => {
+    const deps = makeDeps({
+      session: {
+        list: async () => ({ data: undefined, error: null }),
+        status: async () => ({ data: undefined, error: null }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps)
+    const res = await listSessions(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { sessions: unknown[]; statuses: Record<string, unknown> }
+    // Genuinely empty (no error) → fallback to [] / {} as before
+    expect(Array.isArray(body.sessions)).toBe(true)
+    expect(typeof body.statuses).toBe("object")
+  })
+})
+
+// ─── getSessionMessages ───────────────────────────────────────────────────────
+
+describe("getSessionMessages — SDK error propagation", () => {
+  test("500 + logger.error when session.messages returns an error", async () => {
+    const logger = makeSpyLogger()
+    const deps = makeDeps(
+      {
+        session: {
+          messages: async () => ({ data: undefined, error: { message: "session gone" } }),
+        } as unknown as RouteDeps["client"]["session"],
+      },
+      logger,
+    )
+    const ctx = makeCtx(deps, "/sessions/s1/messages", { id: "s1" })
+    const res = await getSessionMessages(ctx)
+    expect(res.status).toBe(500)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("SDK_ERROR")
+    expect(logger.errorCalls.length).toBeGreaterThan(0)
+  })
+
+  test("404 when session.messages returns a not-found error", async () => {
+    const logger = makeSpyLogger()
+    const deps = makeDeps(
+      {
+        session: {
+          messages: async () => ({ data: undefined, error: { message: "404 not found" } }),
+        } as unknown as RouteDeps["client"]["session"],
+      },
+      logger,
+    )
+    const ctx = makeCtx(deps, "/sessions/s1/messages", { id: "s1" })
+    const res = await getSessionMessages(ctx)
+    expect(res.status).toBe(404)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("NOT_FOUND")
+  })
+
+  test("200 with messages array when SDK succeeds", async () => {
+    const deps = makeDeps({
+      session: {
+        messages: async () => ({ data: [{ id: "m1" }], error: null }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps, "/sessions/s1/messages", { id: "s1" })
+    const res = await getSessionMessages(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as unknown[]
+    expect(body).toEqual([{ id: "m1" }])
+  })
+
+  test("200 with empty array when SDK returns no data but no error", async () => {
+    const deps = makeDeps({
+      session: {
+        messages: async () => ({ data: undefined, error: null }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps, "/sessions/s1/messages", { id: "s1" })
+    const res = await getSessionMessages(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as unknown[]
+    expect(Array.isArray(body)).toBe(true)
+  })
+})
+
+// ─── getSessionDiff ───────────────────────────────────────────────────────────
+
+describe("getSessionDiff — SDK error propagation", () => {
+  test("500 + logger.error when session.diff returns an error", async () => {
+    const logger = makeSpyLogger()
+    const deps = makeDeps(
+      {
+        session: {
+          diff: async () => ({ data: undefined, error: { message: "IPC down" } }),
+        } as unknown as RouteDeps["client"]["session"],
+      },
+      logger,
+    )
+    const ctx = makeCtx(deps, "/sessions/s1/diff", { id: "s1" })
+    const res = await getSessionDiff(ctx)
+    expect(res.status).toBe(500)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("SDK_ERROR")
+    expect(logger.errorCalls.length).toBeGreaterThan(0)
+  })
+
+  test("404 when session.diff returns a not-found error", async () => {
+    const deps = makeDeps({
+      session: {
+        diff: async () => ({ data: undefined, error: { message: "session not found" } }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps, "/sessions/s1/diff", { id: "s1" })
+    const res = await getSessionDiff(ctx)
+    expect(res.status).toBe(404)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("NOT_FOUND")
+  })
+
+  test("200 with diff data when SDK succeeds", async () => {
+    const deps = makeDeps({
+      session: {
+        diff: async () => ({ data: ["diff-line-1"], error: null }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps, "/sessions/s1/diff", { id: "s1" })
+    const res = await getSessionDiff(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as unknown[]
+    expect(body).toEqual(["diff-line-1"])
+  })
+
+  test("200 with empty array when SDK returns no data but no error", async () => {
+    const deps = makeDeps({
+      session: {
+        diff: async () => ({ data: undefined, error: null }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps, "/sessions/s1/diff", { id: "s1" })
+    const res = await getSessionDiff(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as unknown[]
+    expect(Array.isArray(body)).toBe(true)
+  })
+})
+
+// ─── getSessionChildren ───────────────────────────────────────────────────────
+
+describe("getSessionChildren — SDK error propagation", () => {
+  test("500 + logger.error when session.children returns an error", async () => {
+    const logger = makeSpyLogger()
+    const deps = makeDeps(
+      {
+        session: {
+          children: async () => ({ data: undefined, error: { message: "IPC down" } }),
+        } as unknown as RouteDeps["client"]["session"],
+      },
+      logger,
+    )
+    const ctx = makeCtx(deps, "/sessions/s1/children", { id: "s1" })
+    const res = await getSessionChildren(ctx)
+    expect(res.status).toBe(500)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("SDK_ERROR")
+    expect(logger.errorCalls.length).toBeGreaterThan(0)
+  })
+
+  test("404 when session.children returns a not-found error", async () => {
+    const deps = makeDeps({
+      session: {
+        children: async () => ({ data: undefined, error: { message: "404 session not found" } }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps, "/sessions/s1/children", { id: "s1" })
+    const res = await getSessionChildren(ctx)
+    expect(res.status).toBe(404)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("NOT_FOUND")
+  })
+
+  test("200 with children array when SDK succeeds", async () => {
+    const deps = makeDeps({
+      session: {
+        children: async () => ({ data: [{ id: "child-1" }], error: null }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps, "/sessions/s1/children", { id: "s1" })
+    const res = await getSessionChildren(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as unknown[]
+    expect(body).toEqual([{ id: "child-1" }])
+  })
+
+  test("200 with empty array when SDK returns no data but no error", async () => {
+    const deps = makeDeps({
+      session: {
+        children: async () => ({ data: undefined, error: null }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps, "/sessions/s1/children", { id: "s1" })
+    const res = await getSessionChildren(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as unknown[]
+    expect(Array.isArray(body)).toBe(true)
+  })
+})
+
+// ─── listTools ────────────────────────────────────────────────────────────────
+
+describe("listTools — SDK error propagation", () => {
+  test("500 + logger.error when tool.ids returns an error", async () => {
+    const logger = makeSpyLogger()
+    const deps = makeDeps(
+      {
+        tool: {
+          ids: async () => ({ data: undefined, error: { message: "IPC down" } }),
+        } as unknown as RouteDeps["client"]["tool"],
+      },
+      logger,
+    )
+    const ctx = makeCtx(deps, "/tools")
+    const res = await listTools(ctx)
+    expect(res.status).toBe(500)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("SDK_ERROR")
+    expect(logger.errorCalls.length).toBeGreaterThan(0)
+  })
+
+  test("200 with tool IDs when SDK succeeds", async () => {
+    const deps = makeDeps({
+      tool: {
+        ids: async () => ({ data: ["bash", "python"], error: null }),
+      } as unknown as RouteDeps["client"]["tool"],
+    })
+    const ctx = makeCtx(deps, "/tools")
+    const res = await listTools(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as unknown[]
+    expect(body).toEqual(["bash", "python"])
+  })
+
+  test("200 with empty array when SDK returns no data but no error", async () => {
+    const deps = makeDeps({
+      tool: {
+        ids: async () => ({ data: undefined, error: null }),
+      } as unknown as RouteDeps["client"]["tool"],
+    })
+    const ctx = makeCtx(deps, "/tools")
+    const res = await listTools(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as unknown[]
+    expect(Array.isArray(body)).toBe(true)
+  })
+})
+
+// ─── getStatus ────────────────────────────────────────────────────────────────
+
+describe("getStatus — SDK error propagation", () => {
+  test("500 + logger.error when session.list returns an error", async () => {
+    const logger = makeSpyLogger()
+    const deps = makeDeps(
+      {
+        session: {
+          list: async () => ({ data: undefined, error: { message: "IPC down" } }),
+          status: async () => ({ data: {}, error: null }),
+        } as unknown as RouteDeps["client"]["session"],
+      },
+      logger,
+    )
+    const ctx = makeCtx(deps, "/status")
+    const res = await getStatus(ctx)
+    expect(res.status).toBe(500)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("SDK_ERROR")
+    expect(logger.errorCalls.length).toBeGreaterThan(0)
+  })
+
+  test("500 + logger.error when session.status returns an error", async () => {
+    const logger = makeSpyLogger()
+    const deps = makeDeps(
+      {
+        session: {
+          list: async () => ({ data: [], error: null }),
+          status: async () => ({ data: undefined, error: { message: "IPC down" } }),
+        } as unknown as RouteDeps["client"]["session"],
+      },
+      logger,
+    )
+    const ctx = makeCtx(deps, "/status")
+    const res = await getStatus(ctx)
+    expect(res.status).toBe(500)
+    const body = await res.json() as { error: { code: string } }
+    expect(body.error.code).toBe("SDK_ERROR")
+    expect(logger.errorCalls.length).toBeGreaterThan(0)
+  })
+
+  test("200 with correct shape when both SDK calls succeed", async () => {
+    const deps = makeDeps({
+      session: {
+        list: async () => ({ data: [{ id: "s1" }, { id: "s2" }], error: null }),
+        status: async () => ({ data: { s1: "running", s2: "idle" }, error: null }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps, "/status")
+    const res = await getStatus(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as {
+      pilot: { version: string; uptime: number }
+      sessions: { total: number; statuses: Record<string, unknown> }
+      clients: number
+    }
+    expect(body.sessions.total).toBe(2)
+    expect(body.sessions.statuses).toEqual({ s1: "running", s2: "idle" })
+    expect(body.pilot.version).toBe("0.0.0-test")
+  })
+
+  test("200 with zero sessions when SDK returns no data but no error", async () => {
+    const deps = makeDeps({
+      session: {
+        list: async () => ({ data: undefined, error: null }),
+        status: async () => ({ data: undefined, error: null }),
+      } as unknown as RouteDeps["client"]["session"],
+    })
+    const ctx = makeCtx(deps, "/status")
+    const res = await getStatus(ctx)
+    expect(res.status).toBe(200)
+    const body = await res.json() as {
+      sessions: { total: number; statuses: Record<string, unknown> }
+    }
+    // Genuinely empty → fallback 0 / {}
+    expect(body.sessions.total).toBe(0)
+    expect(typeof body.sessions.statuses).toBe("object")
+  })
+})

--- a/src/transport/http/handlers/sdk-proxy.ts
+++ b/src/transport/http/handlers/sdk-proxy.ts
@@ -15,6 +15,14 @@ export async function listTools({ url, deps }: RouteContext): Promise<Response> 
   if (dirParam === null)
     return jsonError("INVALID_DIRECTORY", "Internal error: the dashboard sent an invalid directory path. Try refreshing the page; if it persists, report at https://github.com/lesquel/open-remote-control/issues.", 400, CORS_HEADERS)
   const result = await deps.client.tool.ids({ query: { ...dirParam } })
+  if (result.error) {
+    const errMsg =
+      typeof result.error === "object" && result.error !== null && "message" in result.error
+        ? String((result.error as { message?: unknown }).message ?? "")
+        : String(result.error)
+    deps.logger.error("SDK call failed: tool.ids", { error: errMsg })
+    return jsonError("SDK_ERROR", "SDK call failed", 500, CORS_HEADERS)
+  }
   return json(result.data ?? [], 200, CORS_HEADERS)
 }
 

--- a/src/transport/http/handlers/sessions.ts
+++ b/src/transport/http/handlers/sessions.ts
@@ -12,12 +12,34 @@ import { validateEndpoint } from "../../../infra/network/ssrf"
 import { ATTACHMENT_MAX_BYTES, MIME_SAFELIST } from "../../../infra/http/constants"
 import type { FilePart } from "@opencode-ai/sdk"
 
+// ─── Shared SDK error inspector ───────────────────────────────────────────────
+
+/**
+ * Extract a human-readable message from an SDK error value.
+ * Mirrors the exact pattern used in deleteSession (the established in-repo reference).
+ */
+function sdkErrorMessage(error: unknown): string {
+  return typeof error === "object" && error !== null && "message" in error
+    ? String((error as { message?: unknown }).message ?? "")
+    : String(error)
+}
+
 export async function listSessions({ url, deps }: RouteContext): Promise<Response> {
   const dirParam = extractDirectory(url)
   if (dirParam === null)
     return jsonError("INVALID_DIRECTORY", "Internal error: the dashboard sent an invalid directory path. Try refreshing the page; if it persists, report at https://github.com/lesquel/open-remote-control/issues.", 400, CORS_HEADERS)
   const result = await deps.client.session.list({ query: { ...dirParam } })
+  if (result.error) {
+    const errMsg = sdkErrorMessage(result.error)
+    deps.logger.error("SDK call failed: session.list", { error: errMsg })
+    return jsonError("SDK_ERROR", "SDK call failed", 500, CORS_HEADERS)
+  }
   const statuses = await deps.client.session.status({ query: { ...dirParam } })
+  if (statuses.error) {
+    const errMsg = sdkErrorMessage(statuses.error)
+    deps.logger.error("SDK call failed: session.status", { error: errMsg })
+    return jsonError("SDK_ERROR", "SDK call failed", 500, CORS_HEADERS)
+  }
   return json(
     { sessions: result.data ?? [], statuses: statuses.data ?? {} },
     200,
@@ -171,6 +193,14 @@ export async function getSessionMessages({
   if (dirParam === null)
     return jsonError("INVALID_DIRECTORY", "Internal error: the dashboard sent an invalid directory path. Try refreshing the page; if it persists, report at https://github.com/lesquel/open-remote-control/issues.", 400, CORS_HEADERS)
   const result = await deps.client.session.messages({ path: { id: params.id }, query: { ...dirParam } })
+  if (result.error) {
+    const errMsg = sdkErrorMessage(result.error)
+    if (/404|not.*found/i.test(errMsg)) {
+      return jsonError("NOT_FOUND", "Session not found", 404, CORS_HEADERS)
+    }
+    deps.logger.error("SDK call failed: session.messages", { sessionID: params.id, error: errMsg })
+    return jsonError("SDK_ERROR", "SDK call failed", 500, CORS_HEADERS)
+  }
   return json(result.data ?? [], 200, CORS_HEADERS)
 }
 
@@ -179,6 +209,14 @@ export async function getSessionDiff({ url, params, deps }: RouteContext): Promi
   if (dirParam === null)
     return jsonError("INVALID_DIRECTORY", "Internal error: the dashboard sent an invalid directory path. Try refreshing the page; if it persists, report at https://github.com/lesquel/open-remote-control/issues.", 400, CORS_HEADERS)
   const result = await deps.client.session.diff({ path: { id: params.id }, query: { ...dirParam } })
+  if (result.error) {
+    const errMsg = sdkErrorMessage(result.error)
+    if (/404|not.*found/i.test(errMsg)) {
+      return jsonError("NOT_FOUND", "Session not found", 404, CORS_HEADERS)
+    }
+    deps.logger.error("SDK call failed: session.diff", { sessionID: params.id, error: errMsg })
+    return jsonError("SDK_ERROR", "SDK call failed", 500, CORS_HEADERS)
+  }
   return json(result.data ?? [], 200, CORS_HEADERS)
 }
 
@@ -195,6 +233,14 @@ export async function getSessionChildren({
   if (dirParam === null)
     return jsonError("INVALID_DIRECTORY", "Internal error: the dashboard sent an invalid directory path. Try refreshing the page; if it persists, report at https://github.com/lesquel/open-remote-control/issues.", 400, CORS_HEADERS)
   const result = await deps.client.session.children({ path: { id: params.id }, query: { ...dirParam } })
+  if (result.error) {
+    const errMsg = sdkErrorMessage(result.error)
+    if (/404|not.*found/i.test(errMsg)) {
+      return jsonError("NOT_FOUND", "Session not found", 404, CORS_HEADERS)
+    }
+    deps.logger.error("SDK call failed: session.children", { sessionID: params.id, error: errMsg })
+    return jsonError("SDK_ERROR", "SDK call failed", 500, CORS_HEADERS)
+  }
   return json(result.data ?? [], 200, CORS_HEADERS)
 }
 

--- a/src/transport/http/handlers/system.ts
+++ b/src/transport/http/handlers/system.ts
@@ -35,7 +35,23 @@ export function getIP(req: Request): string {
 
 export async function getStatus({ deps }: RouteContext): Promise<Response> {
   const sessions = await deps.client.session.list()
+  if (sessions.error) {
+    const errMsg =
+      typeof sessions.error === "object" && sessions.error !== null && "message" in sessions.error
+        ? String((sessions.error as { message?: unknown }).message ?? "")
+        : String(sessions.error)
+    deps.logger.error("SDK call failed: session.list", { error: errMsg })
+    return jsonError("SDK_ERROR", "SDK call failed", 500, CORS_HEADERS)
+  }
   const statuses = await deps.client.session.status()
+  if (statuses.error) {
+    const errMsg =
+      typeof statuses.error === "object" && statuses.error !== null && "message" in statuses.error
+        ? String((statuses.error as { message?: unknown }).message ?? "")
+        : String(statuses.error)
+    deps.logger.error("SDK call failed: session.status", { error: errMsg })
+    return jsonError("SDK_ERROR", "SDK call failed", 500, CORS_HEADERS)
+  }
   return json(
     {
       pilot: { version: deps.pilotVersion, uptime: process.uptime() },


### PR DESCRIPTION
## Summary

Resolves the **SDK `result.error` consistency** item of #33 (Tier-2; convergent across the domain-logic + silent-failures passes).

Six SDK-backed read handlers did `json(result.data ?? [], 200)` **without checking `result.error`**. On SDK failure (IPC down, session vanished, OpenCode restarting) the dashboard rendered "empty" instead of surfacing the error — silent failure, inconsistent with `getSession`/`updateSession`/`deleteSession`/`postSessionPrompt` which already check.

## Fix — mirrors the existing `deleteSession` precedent exactly

| Handler | File | Behavior on SDK error |
|---|---|---|
| `listSessions` | sessions.ts | either of the 2 calls errors → fail (no half-empty 200) |
| `getSessionMessages` / `getSessionDiff` / `getSessionChildren` | sessions.ts | not-found → 404; generic → 500 + `logger.error` |
| `listTools` | sdk-proxy.ts | generic → 500 + `logger.error` |
| `getStatus` | system.ts | either of the 2 calls errors → 500 + `logger.error` |

- **Success/empty paths byte-identical** — same `?? []`/`?? {}` fallback, status 200, CORS headers. Only error early-returns were added.
- Status codes/error codes match the in-repo `deleteSession`/`postSessionPrompt` precedent (404 `NOT_FOUND` / 500 `SDK_ERROR`) — no new convention.
- Extracted `sdkErrorMessage()` from `deleteSession`'s inline logic (behaviorally identical) to avoid 4× duplication.
- `getSession` deliberately **untouched** (its 404-on-any-error is separately tracked on #25).

## Testing

- [x] +23 tests (error → non-200 + `logger.error` called; not-found → 404; success/empty → original 200 shape unchanged). Independent spy logger per test, non-flaky.
- [x] `bun test` 647/0 · `bunx tsc --noEmit` clean
- [x] Independent fresh-context review: **APPROVE, no blocking issues** — all 7 checks PASS, incl. an exhaustive old-vs-new diff confirming the success path is byte-identical. The single nit (unused test import) is fixed.

## Merge note

Independent off `main`. Touches `system.ts` (`getStatus`) — open PR #34 also touches `system.ts` but a different function (`rotateAuthToken`); non-overlapping hunks → clean 3-way merge in any order. `sessions.ts`/`sdk-proxy.ts` don't overlap #34/#35.

Refs #33 (Tier-2, partial — does not close).
