### PR TITLE
fix(dashboard): make Codex permission requests visible in the dashboard

### DIFF
--- a/src/dashboard/__tests__/codex-permission-alias.test.ts
+++ b/src/dashboard/__tests__/codex-permission-alias.test.ts
@@ -1,0 +1,157 @@
+// codex-permission-alias.test.ts — TDD for the Codex permission dashboard alias fix.
+//
+// Bug: Codex emits `pilot.permission.pending` / `pilot.permission.resolved` but
+// the dashboard only handled `permission.requested` / `permission.resolved`.
+// Fix: add named constants for the pilot event types and handle them as aliases
+// in the SSE handleEvent switch.
+//
+// These tests run against pure modules (no browser APIs needed):
+//   - constants.js   — verifies the new constants are defined with correct values
+//   - permission-normalize.js — verifies the pure normalization helper works for
+//     both native OpenCode payload shapes and Codex payload shapes
+
+import { describe, expect, test } from "bun:test"
+import { EVENTS } from "../constants.js"
+import {
+  normalizePermissionPending,
+  normalizePermissionResolved,
+} from "../sse/permission-normalize.js"
+
+// ── Step 1: constants ─────────────────────────────────────────────────────────
+
+describe("constants.js — pilot permission alias event types", () => {
+  // FAILING until constants are added: EVENTS.PERMISSION_PENDING_PILOT and
+  // EVENTS.PERMISSION_RESOLVED_PILOT must exist with the exact strings that
+  // Codex emits.
+
+  test("EVENTS.PERMISSION_PENDING_PILOT equals 'pilot.permission.pending'", () => {
+    expect(EVENTS.PERMISSION_PENDING_PILOT).toBe("pilot.permission.pending")
+  })
+
+  test("EVENTS.PERMISSION_RESOLVED_PILOT equals 'pilot.permission.resolved'", () => {
+    expect(EVENTS.PERMISSION_RESOLVED_PILOT).toBe("pilot.permission.resolved")
+  })
+
+  test("native PERMISSION_REQUESTED constant is unchanged (no regression)", () => {
+    expect(EVENTS.PERMISSION_REQUESTED).toBe("permission.requested")
+  })
+
+  test("native PERMISSION_RESOLVED constant is unchanged (no regression)", () => {
+    expect(EVENTS.PERMISSION_RESOLVED).toBe("permission.resolved")
+  })
+})
+
+// ── Step 2: normalization helper ──────────────────────────────────────────────
+
+describe("normalizePermissionPending — Codex payload shape", () => {
+  // The exact payload Codex emits in handlers.ts ~line 275:
+  //   { permissionID, title: `Codex: ${tool_name}`, sessionID, permissionType, metadata }
+  const codexEvent = {
+    type: "pilot.permission.pending",
+    properties: {
+      permissionID: "uuid-123",
+      title: "Codex: BashTool",
+      sessionID: "sess-abc",
+      permissionType: "codex-tool",
+      metadata: { tool_name: "BashTool", source: "codex-hook" },
+    },
+  }
+
+  test("normalizePermissionPending exists and handles Codex payload", () => {
+    const normalized = normalizePermissionPending(codexEvent)
+    expect(normalized.id).toBe("uuid-123")
+    expect(normalized.permissionID).toBe("uuid-123")
+    expect(normalized.title).toBe("Codex: BashTool")
+    expect(normalized.sessionID).toBe("sess-abc")
+    expect(normalized.type).toBe("codex-tool")
+    expect(normalized.metadata).toEqual({ tool_name: "BashTool", source: "codex-hook" })
+  })
+
+  test("normalizePermissionPending handles native OpenCode payload shape", () => {
+    // Native OpenCode events carry the same fields under .properties
+    const nativeEvent = {
+      type: "permission.requested",
+      properties: {
+        permissionID: "native-uuid-456",
+        title: "Shell: rm -rf",
+        sessionID: "sess-native",
+        permissionType: "shell",
+        pattern: "/tmp/**",
+        metadata: { command: "rm -rf /tmp/foo" },
+      },
+    }
+    const normalized = normalizePermissionPending(nativeEvent)
+    expect(normalized.id).toBe("native-uuid-456")
+    expect(normalized.title).toBe("Shell: rm -rf")
+    expect(normalized.pattern).toBe("/tmp/**")
+  })
+
+  test("normalizePermissionPending handles .data shape (EventSource named-event path)", () => {
+    // Named SSE events wrap the payload in .data
+    const namedEvent = {
+      type: "permission.requested",
+      data: {
+        permissionID: "evt-data-789",
+        title: "Read file",
+        sessionID: "sess-data",
+        permissionType: "read",
+      },
+    }
+    const normalized = normalizePermissionPending(namedEvent)
+    expect(normalized.id).toBe("evt-data-789")
+    expect(normalized.sessionID).toBe("sess-data")
+  })
+
+  test("pattern field is undefined (not present) for Codex events — safe default", () => {
+    // Codex does NOT send a pattern field. The normalize should produce
+    // pattern: undefined (not throw) so the banner gracefully shows no detail.
+    const normalized = normalizePermissionPending(codexEvent)
+    expect(normalized.pattern).toBeUndefined()
+  })
+})
+
+describe("normalizePermissionResolved — Codex payload shape", () => {
+  const codexResolved = {
+    type: "pilot.permission.resolved",
+    properties: {
+      permissionID: "uuid-123",
+      action: "allow",
+      source: "remote",
+    },
+  }
+
+  test("normalizePermissionResolved exists and handles Codex payload", () => {
+    const normalized = normalizePermissionResolved(codexResolved)
+    expect(normalized.id).toBe("uuid-123")
+    expect(normalized.permissionID).toBe("uuid-123")
+  })
+
+  test("normalizePermissionResolved handles client_disconnected reason", () => {
+    const disconnectEvent = {
+      type: "pilot.permission.resolved",
+      properties: {
+        permissionID: "uuid-disconnected",
+        action: "deny",
+        source: "remote",
+        reason: "client_disconnected",
+      },
+    }
+    const normalized = normalizePermissionResolved(disconnectEvent)
+    expect(normalized.id).toBe("uuid-disconnected")
+    expect(normalized.permissionID).toBe("uuid-disconnected")
+  })
+
+  test("normalizePermissionResolved handles timeout reason", () => {
+    const timeoutEvent = {
+      type: "pilot.permission.resolved",
+      properties: {
+        permissionID: "uuid-timeout",
+        action: "deny",
+        source: "remote",
+        reason: "timeout",
+      },
+    }
+    const normalized = normalizePermissionResolved(timeoutEvent)
+    expect(normalized.id).toBe("uuid-timeout")
+  })
+})

--- a/src/dashboard/constants.d.ts
+++ b/src/dashboard/constants.d.ts
@@ -1,0 +1,72 @@
+// Type declarations for the subset of constants.js exports consumed by .test.ts files.
+// constants.js is browser vanilla JS — kept that way because the dashboard ships
+// .js to the browser as static files. This .d.ts gives TypeScript visibility
+// for the symbols our tests touch without forcing a build step.
+
+export declare const EVENTS: {
+  readonly SESSION_UPDATED: string
+  readonly SESSION_CREATED: string
+  readonly SESSION_DELETED: string
+  readonly MESSAGE_CREATED: string
+  readonly MESSAGE_UPDATED: string
+  readonly MESSAGE_PART_UPDATED: string
+  readonly MESSAGE_PART_DELTA: string
+  readonly PERMISSION_REQUESTED: string
+  readonly PERMISSION_RESOLVED: string
+  readonly PERMISSION_PENDING_PILOT: string
+  readonly PERMISSION_RESOLVED_PILOT: string
+  readonly STATUS_CHANGED: string
+  readonly TOOL_COMPLETED: string
+  readonly PILOT_TOOL_COMPLETED: string
+  readonly TODO_UPDATED: string
+  readonly REFERENCES_READY: string
+  readonly VCS_BRANCH_UPDATED: string
+  readonly LSP_UPDATED: string
+  readonly PILOT_SUBAGENT_SPAWNED: string
+}
+
+export declare const LIMITS: {
+  readonly SESSIONS_META_FETCH: number
+  readonly TITLE_MAX_CHARS: number
+  readonly PROMPT_MAX_CHARS: number
+  readonly SSE_BACKOFF_MIN_MS: number
+  readonly SSE_BACKOFF_MAX_MS: number
+  readonly MCP_POLL_INTERVAL_MS: number
+  readonly AGENT_BADGE_MAX_CHARS: number
+  readonly BASH_CMD_PREVIEW_CHARS: number
+  readonly TOOL_ARG_PREVIEW_CHARS: number
+  readonly SCROLL_BOTTOM_THRESHOLD_PX: number
+}
+
+export declare const STATUS_CLASS: {
+  readonly idle: string
+  readonly busy: string
+  readonly error: string
+}
+
+export declare const AGENT_BADGE_CLASS: {
+  readonly plan: string
+  readonly build: string
+  readonly custom: string
+  readonly dynamic: string
+  readonly compact: string
+}
+
+export declare const STORAGE_KEYS: {
+  readonly FOLDER_COLLAPSED: string
+  readonly ACTIVE_DIRECTORY: string
+  readonly MV_PANELS: string
+  readonly MV_ACTIVE: string
+  readonly SUBAGENTS_COLLAPSED: string
+  readonly RIGHT_PANEL_COLLAPSED: string
+  readonly COST_HISTORY: string
+  readonly COST_BUDGET_WARNED: string
+  readonly PINNED_TODOS: string
+  readonly PROJECT_TABS: string
+  readonly ACTIVE_PROJECT_ID: string
+}
+
+export declare const AGENT_COLOR: {
+  readonly SATURATION: number
+  readonly LIGHTNESS: number
+}

--- a/src/dashboard/constants.js
+++ b/src/dashboard/constants.js
@@ -31,9 +31,14 @@ export const EVENTS = Object.freeze({
   // This is what drives the typewriter effect; MESSAGE_PART_UPDATED only
   // carries snapshots (pending → running → completed) without the delta.
   MESSAGE_PART_DELTA:   'message.part.delta',
-  // Permissions
+  // Permissions — native OpenCode SDK events
   PERMISSION_REQUESTED: 'permission.requested',
   PERMISSION_RESOLVED:  'permission.resolved',
+  // Permissions — Codex bridge events (alias: same handler, different type string)
+  // Codex emits these types; renaming the emit would break Telegram/push consumers,
+  // so the dashboard aliases them here instead.
+  PERMISSION_PENDING_PILOT:   'pilot.permission.pending',
+  PERMISSION_RESOLVED_PILOT:  'pilot.permission.resolved',
   // Status / tool
   STATUS_CHANGED:       'status.changed',
   TOOL_COMPLETED:       'tool.completed',

--- a/src/dashboard/sse/permission-normalize.d.ts
+++ b/src/dashboard/sse/permission-normalize.d.ts
@@ -1,0 +1,22 @@
+// Type declarations for permission-normalize.js — consumed by .test.ts files.
+// The module is browser vanilla JS; this .d.ts gives TypeScript visibility
+// without forcing a build step.
+
+export type NormalizedPermissionPending = {
+  id: string | undefined
+  permissionID: string | undefined
+  description: string | undefined
+  title: string | undefined
+  sessionID: string | undefined
+  type: string | undefined
+  pattern: string | undefined
+  metadata: Record<string, unknown> | undefined
+}
+
+export type NormalizedPermissionResolved = {
+  id: string | undefined
+  permissionID: string | undefined
+}
+
+export declare function normalizePermissionPending(ev: Record<string, unknown>): NormalizedPermissionPending
+export declare function normalizePermissionResolved(ev: Record<string, unknown>): NormalizedPermissionResolved

--- a/src/dashboard/sse/permission-normalize.js
+++ b/src/dashboard/sse/permission-normalize.js
@@ -1,0 +1,46 @@
+// permission-normalize.js — Pure helpers that normalize SSE permission events
+// to the stable shape expected by handlePermissionRequested / handlePermissionResolved.
+//
+// Extracted so the logic is testable without importing browser-API-dependent modules.
+// Both native OpenCode events (`permission.requested` / `permission.resolved`) and
+// Codex bridge events (`pilot.permission.pending` / `pilot.permission.resolved`)
+// carry their payload under `ev.properties`. Named-event SSE wrappers may carry
+// the payload under `ev.data` instead — both paths are handled.
+
+/**
+ * Normalize any permission-pending SSE event (native or Codex) to the stable shape
+ * consumed by handlePermissionRequested in permissions.js.
+ *
+ * @param {object} ev  Raw SSE event object: { type, properties?, data? }
+ * @returns {{ id, permissionID, description, title, sessionID, type, pattern, metadata }}
+ */
+export function normalizePermissionPending(ev) {
+  const d = ev.data ?? ev
+  const props = ev.properties ?? d ?? {}
+  return {
+    id:           props.permissionID ?? props.id,
+    permissionID: props.permissionID ?? props.id,
+    description:  props.title ?? props.description,
+    title:        props.title,
+    sessionID:    props.sessionID,
+    type:         props.permissionType ?? props.type,
+    pattern:      props.pattern,
+    metadata:     props.metadata,
+  }
+}
+
+/**
+ * Normalize any permission-resolved SSE event (native or Codex) to the stable shape
+ * consumed by handlePermissionResolved in permissions.js.
+ *
+ * @param {object} ev  Raw SSE event object: { type, properties?, data? }
+ * @returns {{ id, permissionID }}
+ */
+export function normalizePermissionResolved(ev) {
+  const d = ev.data ?? ev
+  const resolvedProps = ev.properties ?? d ?? {}
+  return {
+    id:           resolvedProps.permissionID ?? resolvedProps.id,
+    permissionID: resolvedProps.permissionID ?? resolvedProps.id,
+  }
+}

--- a/src/dashboard/sse/sse.js
+++ b/src/dashboard/sse/sse.js
@@ -17,6 +17,7 @@ import { isFileEditingToolEvent } from '../components/files-changed.js'
 import { debouncedRefreshFilesChanged } from '../components/files-changed-bridge.js'
 import { buildApiUrl } from '../api/api.js'
 import { EVENTS, LIMITS } from '../constants.js'
+import { normalizePermissionPending, normalizePermissionResolved } from './permission-normalize.js'
 import { playNotifySound } from '../ui/notif-sound.js'
 
 let eventSource = null
@@ -77,6 +78,12 @@ const SSE_EVENTS = [
   EVENTS.MESSAGE_PART_DELTA,
   EVENTS.PERMISSION_REQUESTED,
   EVENTS.PERMISSION_RESOLVED,
+  // Codex bridge alias events — same handler paths, different type strings.
+  // The server does not send named `event:` SSE lines today (all events arrive
+  // as unnamed `data:` messages handled by onmessage), but the list must stay
+  // complete so named-event subscriptions are correct if the server ever does.
+  EVENTS.PERMISSION_PENDING_PILOT,
+  EVENTS.PERMISSION_RESOLVED_PILOT,
   EVENTS.STATUS_CHANGED,
   EVENTS.TODO_UPDATED,
 ]
@@ -458,32 +465,21 @@ async function handleEvent(ev) {
     }
   }
 
-  if (t === EVENTS.PERMISSION_REQUESTED) {
-    // Pilot events carry payload under .properties (see notifications.ts).
-    // Normalize to a stable shape for handlers that don't know about .properties.
-    const props = ev.properties ?? d ?? {}
-    const normalized = {
-      id: props.permissionID ?? props.id,
-      permissionID: props.permissionID ?? props.id,
-      description: props.title ?? props.description,
-      title: props.title,
-      sessionID: props.sessionID,
-      type: props.permissionType ?? props.type,
-      pattern: props.pattern,
-      metadata: props.metadata,
-    }
+  // Handle both native OpenCode permission events and Codex bridge aliases.
+  // Codex emits `pilot.permission.pending` / `pilot.permission.resolved` — renaming
+  // those would break Telegram/push consumers, so we alias here instead.
+  if (t === EVENTS.PERMISSION_REQUESTED || t === EVENTS.PERMISSION_PENDING_PILOT) {
+    // Payload may be under .properties (pilot events) or .data (named-event path).
+    // normalizePermissionPending handles both shapes identically.
+    const normalized = normalizePermissionPending(ev)
     handlePermissionRequested(normalized)
     // Dispatch for push-notifications module
     window.dispatchEvent(new CustomEvent('pilot:permission:pending', { detail: normalized }))
   }
 
-  if (t === EVENTS.PERMISSION_RESOLVED) {
-    // pilot.permission.resolved also carries payload under .properties.
-    const resolvedProps = ev.properties ?? d ?? {}
-    const resolvedNormalized = {
-      id: resolvedProps.permissionID ?? resolvedProps.id,
-      permissionID: resolvedProps.permissionID ?? resolvedProps.id,
-    }
+  if (t === EVENTS.PERMISSION_RESOLVED || t === EVENTS.PERMISSION_RESOLVED_PILOT) {
+    // Payload may be under .properties (pilot events) or .data (named-event path).
+    const resolvedNormalized = normalizePermissionResolved(ev)
     handlePermissionResolved(resolvedNormalized)
   }
 


### PR DESCRIPTION
## Summary

Resolves the **Codex permissions invisible in the dashboard** item of #33 (Tier-1; verified by hand).

Native OpenCode permissions reach the dashboard as raw SDK `permission.requested`/`permission.resolved` events. The Codex bridge has **no SDK passthrough** — it emits `pilot.permission.pending`/`pilot.permission.resolved`, which matched **nothing** the dashboard listened for. Result: a Codex tool's approval banner **never appeared**, and would never clear.

## Fix — conservative dashboard-side alias

Deliberately **not** changing the emitted event type: the notification pipeline (Telegram/push) consumes `pilot.permission.pending`; renaming it risks regressing those consumers. Fixed purely in the dashboard:

- `constants.js`: add `PERMISSION_PENDING_PILOT` / `PERMISSION_RESOLVED_PILOT` (named constants — no bare literals).
- `sse.js`: the `PERMISSION_REQUESTED` / `PERMISSION_RESOLVED` branches now also match the two `pilot.*` types — **purely additive OR-extension**, native event strings unchanged.
- Extracted the inline normalization into a shared `sse/permission-normalize.js` used by **both** native and Codex paths. The fresh review verified the helpers are **byte-equivalent** to the original inline code via a field-by-field table (every field, `??` fallback order, and key name preserved) → native rendering is provably unchanged.

## Verification highlights

- **Native byte-equivalence**: fresh-context review's make-or-break check — PASS (exhaustive old-vs-new diff).
- **Codex payload parity**: pending carries `permissionID/title/sessionID/permissionType/metadata`; missing `pattern` degrades safely. All Codex resolved exits (normal/timeout/client-disconnect) carry `permissionID` → clear path works for every outcome.
- **Path reachable**: SSE is unnamed (`data:` only) so `onmessage` already receives these events; `SSE_EVENTS` is not a hard filter (the two types added there anyway for forward-compat).
- `.d.ts` companions for the new JS follow the **established in-repo pattern** for testing vanilla dashboard JS from TS tests.

## Testing

- [x] +11 tests (pilot events normalize identically to native; all 3 resolved variants; `pattern`-absent safe default)
- [x] `bun test` 635/0 · `bunx tsc --noEmit` clean
- [x] Independent fresh-context adversarial review: **APPROVE, no blocking issues**. The actionable nit (misleading `FAILING:` test-name prefixes) is fixed.

Independent off `main`, dashboard-only — no overlap with #34–37.

Refs #33 (Tier-1, partial — does not close).
