### PR TITLE
fix: handle Telegram poll conflicts and ngrok dev URLs

### DIFF
--- a/src/infra/tunnel/__tests__/url-extractor.test.ts
+++ b/src/infra/tunnel/__tests__/url-extractor.test.ts
@@ -63,5 +63,12 @@ describe("createUrlExtractor", () => {
         "https://abc-def.ngrok-free.app",
       )
     })
+
+    test("extracts ngrok-free dev URLs", () => {
+      const extractor = createUrlExtractor(TUNNEL_URL_PATTERNS.ngrok)
+      expect(
+        extractor.feed("Forwarding https://abc-def.ngrok-free.dev -> http://localhost:3000\n"),
+      ).toBe("https://abc-def.ngrok-free.dev")
+    })
   })
 })

--- a/src/infra/tunnel/constants.ts
+++ b/src/infra/tunnel/constants.ts
@@ -11,5 +11,5 @@ export const TUNNEL_KILL_GRACE_MS = 400
 /** Regex patterns for extracting the public URL from tunnel process output. */
 export const TUNNEL_URL_PATTERNS = {
   cloudflared: /https:\/\/[a-z0-9-]+\.trycloudflare\.com/,
-  ngrok: /https:\/\/[a-z0-9-]+\.ngrok(-free)?\.app/,
+  ngrok: /https:\/\/[a-z0-9-]+\.ngrok(-free)?\.(?:app|dev)/,
 } as const

--- a/src/notifications/channels/telegram/index.test.ts
+++ b/src/notifications/channels/telegram/index.test.ts
@@ -159,6 +159,56 @@ describe("D2 — abortable sleep on stop()", () => {
   beforeEach(() => { originalFetch = globalThis.fetch })
   afterEach(() => { globalThis.fetch = originalFetch })
 
+  test("stops polling instead of retrying when another getUpdates poller is active", async () => {
+    const logger = makeLogger()
+    const q = createPermissionQueue(5_000)
+    let getUpdatesCalls = 0
+    let loopSettled = false
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (!url.includes("/getUpdates")) {
+        return new Response(JSON.stringify({ ok: true, result: true }), {
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+
+      getUpdatesCalls++
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          description: "Conflict: terminated by other getUpdates request",
+        }),
+        { status: 409, headers: { "Content-Type": "application/json" } },
+      )
+    }) as unknown as typeof globalThis.fetch
+
+    const bot = createTelegramChannel(
+      { token: "fake-token", chatId: "12345" },
+      q,
+      q,
+      logger,
+      {
+        backoffStepsMs: [10],
+        onLoopSettled: () => { loopSettled = true },
+      },
+    )
+
+    try {
+      await new Promise<void>((r) => setTimeout(r, 80))
+      expect(loopSettled).toBe(true)
+      expect(getUpdatesCalls).toBe(1)
+
+      const infoLogs = logger.calls.info ?? []
+      const stoppedLog = infoLogs.some((args) =>
+        args.some((a) => String(a).toLowerCase().includes("another poller")),
+      )
+      expect(stoppedLog).toBe(true)
+    } finally {
+      bot.stop()
+    }
+  }, 5_000)
+
   test("stop() aborts backoff sleep — loop settles within abort window, not after full sleep duration", async () => {
     // D2 observable: loop must SETTLE (pollLoop promise resolves) promptly after stop().
     // We inject a 500ms backoff. Without the fix: loop settles at t≈500ms.

--- a/src/notifications/channels/telegram/index.ts
+++ b/src/notifications/channels/telegram/index.ts
@@ -7,12 +7,18 @@ import type { NotificationChannel, NotificationResult } from "../../ports"
 
 /** Default fetch timeout for all Telegram API calls. */
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000
+const TELEGRAM_POLL_CONFLICT_FRAGMENT = "terminated by other getUpdates request"
 
 function getTelegramFetchTimeoutMs(): number {
   const raw = process.env.PILOT_FETCH_TIMEOUT_MS
   if (!raw) return DEFAULT_FETCH_TIMEOUT_MS
   const n = parseInt(raw, 10)
   return Number.isFinite(n) && n > 0 ? n : DEFAULT_FETCH_TIMEOUT_MS
+}
+
+function isTelegramPollConflict(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return msg.includes(TELEGRAM_POLL_CONFLICT_FRAGMENT)
 }
 
 /**
@@ -255,6 +261,14 @@ export function createTelegramChannel(
             }
           }
         } catch (err) {
+          if (isTelegramPollConflict(err)) {
+            polling = false
+            if (logger) {
+              logger.info("Telegram polling stopped — another poller is already active")
+            }
+            return
+          }
+
           const delay = BACKOFF_STEPS[Math.min(backoffIdx, BACKOFF_STEPS.length - 1)]!
           if (logger) {
             logger.warn("Telegram polling failed", {
@@ -443,4 +457,3 @@ export function createTelegramChannel(
     },
   }
 }
-


### PR DESCRIPTION
Fixes #42

## Summary
- stop the Telegram long-poll loop when Telegram reports that another getUpdates poller is already active
- keep the first active poller running instead of retrying duplicate pollers forever
- recognize ngrok-free `.dev` tunnel URLs in tunnel output parsing

## Root cause
OpenCode can initialize the plugin twice in the same process, which starts duplicate Telegram getUpdates loops. Telegram rejects the duplicate long poll with a 409 conflict, but the plugin treated it as a generic transient polling failure and retried indefinitely. The ngrok tunnel extractor also only matched `.app` ngrok domains, so `.ngrok-free.dev` URLs were ignored.

## Validation
- failing-first `bun test src/infra/tunnel/__tests__/url-extractor.test.ts` failed before the regex change and passes after
- failing-first `bun test src/notifications/channels/telegram/index.test.ts` failed before the poll conflict handling and passes after
- `bun run typecheck`
- `bun run lint` (0 errors; existing warnings remain)
- `bun test` (733 pass)
- `bun run prepublishOnly`
- `git diff --check`